### PR TITLE
chore: fix readme query cost rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ There is an up-front processing cost, as well as a per-query cost.
 | 16kb      | 574k                               |
 
 | query type | query cost (in megaplonk gaes) |
+|-|-|
 | `get_value` | 364 |
 | `get_number` | 454 |
 | `get_literal` | 416 |


### PR DESCRIPTION
The query cost table was not rendering properly due to the missing separator, this makes it show up as a table in the readme.

![image](https://github.com/user-attachments/assets/24f26138-cdc3-4ce2-b50e-a53823b98036)
