### PR TITLE
fix!: replace usage of u16s in generics with u32s

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ If the predefined JSON types are not sufficient for your use case, you can defin
 
 The JSON struct in `dep::json_parser::json::JSON` is parametrised with the following parameters:
 
-`struct JSON<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let MaxNumValues: u16, let MaxKeyFields: u16>`
+`struct JSON<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let MaxNumValues: u32, let MaxKeyFields: u32>`
 
 - `NumBytes` : the maximum size of the initial json blob
 - `NumPackedFields` : take `NumBytes / 31`, round up to the nearest integer, then add 3!

--- a/src/_comparison_tools/bounds_checker.nr
+++ b/src/_comparison_tools/bounds_checker.nr
@@ -27,14 +27,14 @@ in this case, i == M
  * @description this method is cheaper than querying `i < boundary` for `u16` and `u32` types
  *              cost = 3 gates + 2 gates per iteration 
  **/
-pub fn get_validity_flags<let N: u16>(boundary: u16) -> [Field; N] {
+pub fn get_validity_flags<let N: u32>(boundary: u32) -> [Field; N] {
     let flags: [Field; N] = __get_validity_flags(boundary);
     get_validity_flags_inner(boundary, flags)
 }
 
-unconstrained fn __get_validity_flags<let N: u16>(boundary: u16) -> [Field; N] {
+unconstrained fn __get_validity_flags<let N: u32>(boundary: u32) -> [Field; N] {
     let mut result: [Field; N] = [0; N];
-    for i in 0..N as u16 {
+    for i in 0..N as u32 {
         if i < boundary {
             result[i] = 1;
         }
@@ -55,7 +55,7 @@ unconstrained fn __get_validity_flags<let N: u16>(boundary: u16) -> [Field; N] {
  *                 aligns with what is expected from testing `i < boundary`
  *  N.B. this method will revert if `boundary > N`
  **/
-fn get_validity_flags_inner<let N: u16>(boundary: u16, flags: [Field; N]) -> [Field; N] {
+fn get_validity_flags_inner<let N: u32>(boundary: u32, flags: [Field; N]) -> [Field; N] {
     let initial_flag = flags[0];
     let final_flag = flags[N - 1];
 

--- a/src/_comparison_tools/bounds_checker.nr
+++ b/src/_comparison_tools/bounds_checker.nr
@@ -34,7 +34,7 @@ pub fn get_validity_flags<let N: u32>(boundary: u32) -> [Field; N] {
 
 unconstrained fn __get_validity_flags<let N: u32>(boundary: u32) -> [Field; N] {
     let mut result: [Field; N] = [0; N];
-    for i in 0..N as u32 {
+    for i in 0..N {
         if i < boundary {
             result[i] = 1;
         }

--- a/src/_string_tools/slice_packed_field.nr
+++ b/src/_string_tools/slice_packed_field.nr
@@ -441,8 +441,8 @@ unconstrained fn __slice_field(f: Field, num_bytes: Field) -> [Field; 5] {
 }
 
 unconstrained fn __divmod(numerator: Field, denominator: Field) -> (Field, Field) {
-    let quotient = numerator as u16 / denominator as u16;
-    let remainder = numerator as u16 % denominator as u16;
+    let quotient = numerator as u32 / denominator as u32;
+    let remainder = numerator as u32 % denominator as u32;
     (quotient as Field, remainder as Field)
 }
 
@@ -473,7 +473,7 @@ fn divmod_31(numerator: Field) -> (Field, Field) {
 unconstrained fn decompose(val: Field) -> [Field; 16] {
     let mut r: [Field; 16] = [0; 16];
 
-    let mut it = val as u16;
+    let mut it = val as u32;
     for i in 0..16 {
         r[i] = (it & 1) as Field;
         it >>= 1;
@@ -482,7 +482,7 @@ unconstrained fn decompose(val: Field) -> [Field; 16] {
 }
 
 // 5 gates?
-pub fn get_last_limb_path<let OutputFields: u16>(last_limb_index: Field) -> [Field; OutputFields] {
+pub fn get_last_limb_path<let OutputFields: u32>(last_limb_index: Field) -> [Field; OutputFields] {
     // TODO we offset by 1 explain why (0 byte length produces 0 - 1 which = invalid array index. we just add 1 and increase array length by 1 to compensate)
     let path = LAST_LIMB_PATH[last_limb_index + 1]; // 2
 
@@ -550,7 +550,7 @@ pub fn slice_field(f: Field, num_bytes: Field) -> (Field, Field) {
  * @brief Given an array of fields that pack 31 bytes, return an array that slices the packed byte array at a given index for a given number of bytes
  * @description Some serious dark black magic nonsense going on here. TODO: document
  **/
-pub fn slice_fields<let InputFields: u16, let OutputFields: u16>(
+pub fn slice_fields<let InputFields: u32, let OutputFields: u32>(
     data: [Field; InputFields],
     start_byte: Field,
     num_bytes: Field

--- a/src/_string_tools/string_chopper.nr
+++ b/src/_string_tools/string_chopper.nr
@@ -1,9 +1,9 @@
 use crate::_string_tools::slice_packed_field::slice_fields;
 
-struct StringChopper<let NeedlePackedFields: u16> {}
+struct StringChopper<let NeedlePackedFields: u32> {}
 
-impl<let NeedlePackedFields: u16> StringChopper<NeedlePackedFields> {
-    fn slice_string<let StringBytes: u16, let HaystackPackedFields: u16>(
+impl<let NeedlePackedFields: u32> StringChopper<NeedlePackedFields> {
+    fn slice_string<let StringBytes: u32, let HaystackPackedFields: u32>(
         _: Self,
         haystack: [Field; HaystackPackedFields],
         start_bytes: Field,

--- a/src/_table_generation/make_tables.nr
+++ b/src/_table_generation/make_tables.nr
@@ -341,12 +341,12 @@ unconstrained fn make_token_validation_table() -> [Field; NUM_TOKENS * NUM_TOKEN
     single_value_layer_flags[KEY_TOKEN] = no_token_outcomes;
 
     let mut flattened_flags: [Field; NUM_TOKENS * NUM_TOKENS * 3] = [0; NUM_TOKENS * NUM_TOKENS * 3];
-    let NN = NUM_TOKENS * NUM_TOKENS as Field;
+    let NN = (NUM_TOKENS * NUM_TOKENS) as Field;
     for j in 0..NUM_TOKENS as u32 {
         for k in 0..NUM_TOKENS as u32 {
-            flattened_flags[OBJECT_LAYER * NN + j as Field * NUM_TOKENS + k as Field] = object_layer_flags[j][k];
-            flattened_flags[ARRAY_LAYER * NN + j as Field * NUM_TOKENS + k as Field] = array_layer_flags[j][k];
-            flattened_flags[SINGLE_VALUE_LAYER * NN + j as Field * NUM_TOKENS + k as Field] = single_value_layer_flags[j][k];
+            flattened_flags[OBJECT_LAYER * NN + j as Field * (NUM_TOKENS as Field) + k as Field] = object_layer_flags[j][k];
+            flattened_flags[ARRAY_LAYER * NN + j as Field * (NUM_TOKENS as Field) + k as Field] = array_layer_flags[j][k];
+            flattened_flags[SINGLE_VALUE_LAYER * NN + j as Field * (NUM_TOKENS as Field) + k as Field] = single_value_layer_flags[j][k];
         }
     }
     flattened_flags
@@ -541,17 +541,17 @@ unconstrained fn generate_token_flags_table() -> [Field; NUM_TOKENS * 2] {
     numeric_flags.new_context = ARRAY_LAYER;
     literal_flags.new_context = ARRAY_LAYER;
 
-    flags[NUM_TOKENS + NO_TOKEN] = no_token_flags;
-    flags[NUM_TOKENS + BEGIN_OBJECT_TOKEN] = begin_object_flags;
-    flags[NUM_TOKENS + END_OBJECT_TOKEN] = end_object_flags;
-    flags[NUM_TOKENS + BEGIN_ARRAY_TOKEN] = begin_array_flags;
-    flags[NUM_TOKENS + END_ARRAY_TOKEN] = end_array_flags;
-    flags[NUM_TOKENS + KEY_SEPARATOR_TOKEN] = no_token_flags;
-    flags[NUM_TOKENS + VALUE_SEPARATOR_TOKEN] = no_token_flags;
-    flags[NUM_TOKENS + STRING_TOKEN] = string_flags;
-    flags[NUM_TOKENS + NUMERIC_TOKEN] = numeric_flags;
-    flags[NUM_TOKENS + LITERAL_TOKEN] = literal_flags;
-    flags[NUM_TOKENS + KEY_TOKEN] = key_token_flags;
+    flags[NUM_TOKENS + (NO_TOKEN as u32)] = no_token_flags;
+    flags[NUM_TOKENS + (BEGIN_OBJECT_TOKEN as u32)] = begin_object_flags;
+    flags[NUM_TOKENS + (END_OBJECT_TOKEN as u32)] = end_object_flags;
+    flags[NUM_TOKENS + (BEGIN_ARRAY_TOKEN as u32)] = begin_array_flags;
+    flags[NUM_TOKENS + (END_ARRAY_TOKEN as u32)] = end_array_flags;
+    flags[NUM_TOKENS + (KEY_SEPARATOR_TOKEN as u32)] = no_token_flags;
+    flags[NUM_TOKENS + (VALUE_SEPARATOR_TOKEN as u32)] = no_token_flags;
+    flags[NUM_TOKENS + (STRING_TOKEN as u32)] = string_flags;
+    flags[NUM_TOKENS + (NUMERIC_TOKEN as u32)] = numeric_flags;
+    flags[NUM_TOKENS + (LITERAL_TOKEN as u32)] = literal_flags;
+    flags[NUM_TOKENS + (KEY_TOKEN as u32)] = key_token_flags;
 
     let mut result: [Field; NUM_TOKENS * 2] = [0; NUM_TOKENS * 2];
     for i in 0..(NUM_TOKENS as u32 * 2) {

--- a/src/get_array.nr
+++ b/src/get_array.nr
@@ -8,7 +8,7 @@ use crate::getters::JSONValue;
 /**
  * @brief getter methods for extracting array types out of a JSON struct
  **/
-impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let MaxNumValues: u16, let MaxKeyFields: u16> JSON<NumBytes,NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
+impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let MaxNumValues: u32, let MaxKeyFields: u32> JSON<NumBytes,NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
 
     /**
      * @brief if the root JSON is an array, return its length
@@ -23,7 +23,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      * @brief if the root JSON is an object, extract an array given by `key`
      * @description returns an Option<JSON> where, if the array exists, the JSON object will have the requested array as its root value  
      **/
-    fn get_array<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<Self> {
+    fn get_array<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
         let (exists, key_index) = self.key_exists_impl(key);
         let entry: JSONEntry = self.json_entries_packed[key_index].into();
@@ -44,7 +44,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      * @brief if the root JSON is an object, extract an array given by `key`
      * @description will revert if the array does not exist
      **/
-    fn get_array_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Self {
+    fn get_array_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
 
         let (entry, key_index) = self.get_json_entry_unchecked_with_key_index(key);
@@ -62,7 +62,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief same as `get_array` for where the key length may be less than KeyBytes
      **/
-    fn get_array_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+    fn get_array_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
         let (exists, key_index) = self.key_exists_impl_var(key);
         let entry: JSONEntry = self.json_entries_packed[key_index].into();
@@ -83,7 +83,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief same as `get_array_unchecked` for where the key length may be less than KeyBytes
      **/
-    fn get_array_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
+    fn get_array_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
 
         let (entry, key_index) = self.get_json_entry_unchecked_with_key_index_var(key);

--- a/src/get_literal.nr
+++ b/src/get_literal.nr
@@ -65,13 +65,13 @@ fn extract_literal_from_array(
 /**
  * @brief getter methods for extracting literal values out of a JSON struct
  **/
-impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let MaxNumValues: u16, let MaxKeyFields: u16> JSON<NumBytes,NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
+impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let MaxNumValues: u32, let MaxKeyFields: u32> JSON<NumBytes,NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
 
     /**
      * @brief if the root JSON is an object, extract a literal value given by `key`
      * @description returns an Option<JSONLiteral> which will be null if the literal does not exist
      **/
-    fn get_literal<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<JSONLiteral> {
+    fn get_literal<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<JSONLiteral> {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
 
         let (exists, entry) = self.get_json_entry(key);
@@ -87,7 +87,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      * @brief if the root JSON is an object, extract a literal value given by `key`
      * @description will revert if the literal does not exist
      **/
-    fn get_literal_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> JSONLiteral {
+    fn get_literal_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> JSONLiteral {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
 
         let entry= self.get_json_entry_unchecked(key);
@@ -102,7 +102,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief same as `get_literal` for where the key length may be less than KeyBytes
      **/
-    fn get_literal_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<JSONLiteral> {
+    fn get_literal_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<JSONLiteral> {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
 
         let (exists, entry) = self.get_json_entry_var(key);
@@ -117,7 +117,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief same as `get_literal_unchecked` for where the key length may be less than KeyBytes
      **/
-    fn get_literal_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> JSONLiteral {
+    fn get_literal_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> JSONLiteral {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
 
         let entry= self.get_json_entry_unchecked_var(key);

--- a/src/get_number.nr
+++ b/src/get_number.nr
@@ -28,13 +28,13 @@ fn extract_number_from_array(arr: [u8; U64_LENGTH_AS_BASE10_STRING], json_length
  * @note numeric values must fit into a `u64` type.
  *       decimal values and scientific notation are not yet supported
  **/
-impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let MaxNumValues: u16, let MaxKeyFields: u16> JSON<NumBytes,NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
+impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let MaxNumValues: u32, let MaxKeyFields: u32> JSON<NumBytes,NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
 
     /**
      * @brief if the root JSON is an object, extract a numeric value given by `key`
      * @description returns an Option<u64> which will be null if the key does not exist
      **/
-    fn get_number<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<u64> {
+    fn get_number<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<u64> {
         let (exists, entry) = self.get_json_entry(key);
         assert(
             (entry.entry_type - NUMERIC_TOKEN) * exists as Field == 0, "get_number: entry exists but is not a number!"
@@ -48,7 +48,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      * @brief if the root JSON is an object, extract a u64 value given by `key`
      * @description will revert if the number does not exist
      **/
-    fn get_number_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> u64 {
+    fn get_number_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> u64 {
         let  entry = self.get_json_entry_unchecked(key);
         assert(entry.entry_type == NUMERIC_TOKEN, "get_number_unchecked: entry exists but is not a number!");
         let mut parsed_string: [u8; U64_LENGTH_AS_BASE10_STRING] = self.extract_string_entry(entry);
@@ -59,7 +59,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief same as `get_number` for where the key length may be less than KeyBytes
      **/
-    fn get_number_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64> {
+    fn get_number_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64> {
         let (exists, entry) = self.get_json_entry_var(key);
         assert(
             (entry.entry_type - NUMERIC_TOKEN) * exists as Field == 0, "get_number: entry exists but is not a number!"
@@ -72,7 +72,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief same as `get_number_unchecked` for where the key length may be less than KeyBytes
      **/
-    fn get_number_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> u64 {
+    fn get_number_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> u64 {
         let  entry = self.get_json_entry_unchecked_var(key);
         assert(entry.entry_type == NUMERIC_TOKEN, "get_number_unchecked: entry exists but is not a number!");
         let mut parsed_string: [u8; U64_LENGTH_AS_BASE10_STRING] = self.extract_string_entry(entry);

--- a/src/get_object.nr
+++ b/src/get_object.nr
@@ -8,13 +8,13 @@ use crate::getters::JSONValue;
 /**
  * @brief getter methods for extracting object types out of a JSON struct
  **/
-impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let MaxNumValues: u16, let MaxKeyFields: u16> JSON<NumBytes,NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
+impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let MaxNumValues: u32, let MaxKeyFields: u32> JSON<NumBytes,NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
 
     /**
      * @brief if the root JSON is an object, extract a child object given by `key`
      * @description returns an Option<JSON> where, if the object exists, the JSON object will have the requested object as its root value  
      **/
-    fn get_object<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<Self> {
+    fn get_object<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
 
         let (exists, key_index) = self.key_exists_impl(key);
@@ -35,7 +35,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      * @brief if the root JSON is an object, extract a child object given by `key`
      * @description will revert if the requested object does not exist
      **/
-    fn get_object_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Self {
+    fn get_object_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
         let (entry, key_index) = self.get_json_entry_unchecked_with_key_index(key);
         let entry: JSONEntry = self.json_entries_packed[key_index].into();
@@ -52,7 +52,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief same as `get_object` for where the key length may be less than KeyBytes
      **/
-    fn get_object_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+    fn get_object_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
 
         let (exists, key_index) = self.key_exists_impl_var(key);
@@ -72,7 +72,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief same as `get_object_unchecked` for where the key length may be less than KeyBytes
      **/
-    fn get_object_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
+    fn get_object_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
         let (entry, key_index) = self.get_json_entry_unchecked_with_key_index_var(key);
         let entry: JSONEntry = self.json_entries_packed[key_index].into();

--- a/src/get_string.nr
+++ b/src/get_string.nr
@@ -9,7 +9,7 @@ use crate::enums::Layer::{OBJECT_LAYER, ARRAY_LAYER};
 unconstrained fn to_u8(f: Field) -> u8 {
     f as u8
 }
-fn process_escape_sequences<let N: u16>(input: BoundedVec<u8, N>) -> BoundedVec<u8, N> {
+fn process_escape_sequences<let N: u32>(input: BoundedVec<u8, N>) -> BoundedVec<u8, N> {
     let string = input.storage;
     let mut result: [u8; N] = [0; N];
     let mut result_ptr = 0;
@@ -85,14 +85,14 @@ fn test_process_escape_sequence() {
  * @note returned strings will have escape sequences converted into the relevant ASCII characters.
  *       If you want to avoid this, use `get_value` instead of `get_string`
  **/
-impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let MaxNumValues: u16, let MaxKeyFields: u16> JSON<NumBytes,NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
+impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let MaxNumValues: u32, let MaxKeyFields: u32> JSON<NumBytes,NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
 
     /**
      * @brief if the root JSON is an object, extract a string given by `key`
      * @description returns an Option<BoundedVec> which will be null if the key does not exist
      * @note the `StringBytes` parameter defines the maximum allowable length of the returned string
      **/
-    fn get_string<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> Option<BoundedVec<u8, StringBytes>> {
+    fn get_string<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> Option<BoundedVec<u8, StringBytes>> {
         let (exists, entry) = self.get_json_entry(key);
         assert(
             (entry.entry_type - STRING_TOKEN) * exists as Field == 0, "get_string: entry exists but is not a string!"
@@ -108,7 +108,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      * @description will revert if the string does not exist
      * @note the `StringBytes` parameter defines the maximum allowable length of the returned string
      **/
-    fn get_string_unchecked<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> BoundedVec<u8, StringBytes> {
+    fn get_string_unchecked<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> BoundedVec<u8, StringBytes> {
         let entry = self.get_json_entry_unchecked(key);
         assert(entry.entry_type == STRING_TOKEN, "get_string_unchecked: entry exists but is not a string!");
         let parsed_string = BoundedVec { storage: self.extract_string_entry(entry), len: entry.json_length as u32 };
@@ -118,7 +118,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief same as `get_string` for where the key length may be less than KeyBytes
      **/
-    fn get_string_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<BoundedVec<u8, StringBytes>> {
+    fn get_string_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<BoundedVec<u8, StringBytes>> {
         let (exists, entry) = self.get_json_entry_var(key);
         assert(
             (entry.entry_type - STRING_TOKEN) * exists as Field == 0, "get_string: entry exists but is not a string!"
@@ -131,7 +131,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief same as `get_string_unchecked` for where the key length may be less than KeyBytes
      **/
-    fn get_string_unchecked_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> BoundedVec<u8, StringBytes> {
+    fn get_string_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> BoundedVec<u8, StringBytes> {
         let entry = self.get_json_entry_unchecked_var(key);
         assert(entry.entry_type == STRING_TOKEN, "get_string_unchecked: entry exists but is not a string!");
         let parsed_string = BoundedVec { storage: self.extract_string_entry(entry), len: entry.json_length as u32 };
@@ -142,7 +142,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      * @brief if the root JSON is an array, extract a string given by the position of the target in the source array
      * @description returns an Option<BoundedVec> which will be null if the string does not exist
      **/
-    fn get_string_from_array<let StringBytes: u16>(self, array_index: Field) -> Option<BoundedVec<u8, StringBytes>> {
+    fn get_string_from_array<let StringBytes: u32>(self, array_index: Field) -> Option<BoundedVec<u8, StringBytes>> {
         assert(self.layer_type_of_root == ARRAY_LAYER, "can only acceess array elements from array");
 
         let parent_entry : JSONEntry = self.json_entries_packed[self.root_index_in_transcript].into();
@@ -165,7 +165,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      * @brief if the root JSON is an array, extract a string given by the position of the target in the source array
      * @description will revert if the string does not exist
      **/
-    fn get_string_from_array_unchecked<let StringBytes: u16>(self, array_index: Field) -> BoundedVec<u8, StringBytes> {
+    fn get_string_from_array_unchecked<let StringBytes: u32>(self, array_index: Field) -> BoundedVec<u8, StringBytes> {
         assert(self.layer_type_of_root == ARRAY_LAYER, "can only acceess array elements from array");
 
         let parent_entry : JSONEntry = self.json_entries_packed[self.root_index_in_transcript].into();
@@ -187,7 +187,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief if the root JSON is an object, get a nested string out of the JSON, which may be several keys deep
      **/
-    fn get_string_from_path<let KeyBytes: u16, let StringBytes: u16, let PathDepth: u16>(
+    fn get_string_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
         self,
         keys: [BoundedVec<u8, KeyBytes>; PathDepth]
     ) -> Option<BoundedVec<u8, StringBytes>> {
@@ -210,7 +210,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      * @description returns an Option<JSONValue> which will be null if the key does not exist
      * @note the `StringBytes` parameter defines the maximum allowable length of the returned value
      **/
-    fn get_value<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> Option<JSONValue<StringBytes>> {
+    fn get_value<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> Option<JSONValue<StringBytes>> {
         let (exists, entry) = self.get_json_entry(key);
         let mut parsed_string: [u8; StringBytes] = self.extract_string_entry(entry);
 
@@ -223,7 +223,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      * @description will revert if the string does not exist
      * @note the `StringBytes` parameter defines the maximum allowable length of the returned value
      **/
-    fn get_value_unchecked<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> JSONValue<StringBytes> {
+    fn get_value_unchecked<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> JSONValue<StringBytes> {
         let entry = self.get_json_entry_unchecked(key);
         JSONValue {
             value: BoundedVec { len: entry.json_length as u32, storage: self.extract_string_entry(entry) },
@@ -234,7 +234,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief same as `get_value` for where the key length may be less than KeyBytes
      **/
-    fn get_value_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<JSONValue<StringBytes>> {
+    fn get_value_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<JSONValue<StringBytes>> {
         let (exists, entry) = self.get_json_entry_var(key);
         let mut parsed_string: [u8; StringBytes] = self.extract_string_entry(entry);
 
@@ -245,7 +245,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief same as `get_value_unchecked` for where the key length may be less than KeyBytes
      **/
-    fn get_value_unchecked_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> JSONValue<StringBytes> {
+    fn get_value_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> JSONValue<StringBytes> {
         let entry = self.get_json_entry_unchecked_var(key);
         JSONValue {
             value: BoundedVec { len: entry.json_length as u32, storage: self.extract_string_entry(entry) },
@@ -257,7 +257,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      * @brief if the root JSON is an array, extract a value given by the position of the target in the source array
      * @description returns an Option<BoundedVec> which will be null if the value does not exist
      **/
-    fn get_value_from_array<let StringBytes: u16>(self, array_index: Field) -> Option<JSONValue<StringBytes>> {
+    fn get_value_from_array<let StringBytes: u32>(self, array_index: Field) -> Option<JSONValue<StringBytes>> {
         assert(self.layer_type_of_root == ARRAY_LAYER, "can only acceess array elements from array");
 
         let parent_entry : JSONEntry = self.json_entries_packed[self.root_index_in_transcript].into();
@@ -285,7 +285,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      * @brief if the root JSON is an array, extract a value given by the position of the target in the source array
      * @description will revert if the value does not exist
      **/
-    fn get_value_from_array_unchecked<let StringBytes: u16>(self, array_index: Field) -> JSONValue<StringBytes> {
+    fn get_value_from_array_unchecked<let StringBytes: u32>(self, array_index: Field) -> JSONValue<StringBytes> {
         assert(self.layer_type_of_root == ARRAY_LAYER, "can only acceess array elements from array");
 
         let parent_entry : JSONEntry = self.json_entries_packed[self.root_index_in_transcript].into();
@@ -310,7 +310,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief if the root JSON is an object, get a nested value out of the JSON, which may be several keys deep
      **/
-    fn get_value_from_path<let KeyBytes: u16, let StringBytes: u16, let PathDepth: u16>(
+    fn get_value_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
         self,
         keys: [BoundedVec<u8, KeyBytes>; PathDepth]
     ) -> Option<JSONValue<StringBytes>> {

--- a/src/getters.nr
+++ b/src/getters.nr
@@ -23,13 +23,13 @@ struct KeySearchResult {
 /**
  * @brief helper methods for extracting data out of a processed JSON object
  **/
-impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let MaxNumValues: u16, let MaxKeyFields: u16> JSON<NumBytes,NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
+impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let MaxNumValues: u32, let MaxKeyFields: u32> JSON<NumBytes,NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
 
     /**
      * @brief If the root JSON is an object, extract a JSONEntry that describes an array, object or value that maps to a given key
      * @description returns an Option<JSONEntry> which will be null if the entry does not exist
      **/
-    fn get_json_entry<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> (bool, JSONEntry) {
+    fn get_json_entry<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> (bool, JSONEntry) {
         // let key_index = self.find_key_in_map(keyhash);
         // assert(self.key_hashes[key_index] == keyhash);
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
@@ -43,7 +43,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      * @brief If the root JSON is an object, extract a JSONEntry that describes an array, object or value that maps to a given key
      * @note will revert if the key does not exist
      **/
-    fn get_json_entry_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> JSONEntry {
+    fn get_json_entry_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> JSONEntry {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
 
         let hasher: ByteHasher<MaxKeyFields> = ByteHasher {};
@@ -63,7 +63,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief same as `get_json_entry` but the key length may be less than KeyBytes
      **/
-    fn get_json_entry_var<let KeyBytes: u16>(
+    fn get_json_entry_var<let KeyBytes: u32>(
         self,
         key: BoundedVec<u8, KeyBytes>
     ) -> (bool, JSONEntry) {
@@ -79,11 +79,11 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief same as `get_json_entry_unchecked` but the key length may be less than KeyBytes
      **/
-    fn get_json_entry_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> JSONEntry {
+    fn get_json_entry_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> JSONEntry {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
 
         let hasher: ByteHasher<MaxKeyFields> = ByteHasher {};
-        let keyhash = hasher.get_keyhash_var(key.storage, 0, key.len as u16);
+        let keyhash = hasher.get_keyhash_var(key.storage, 0, key.len as u32);
         let two_pow_216 = 0x100000000000000000000000000000000000000000000000000000000;
 
         let keyhash = keyhash + self.root_id * two_pow_216;
@@ -99,7 +99,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief same as `get_json_entry_unchecked_var` but also returns the position of the JSONEntry in `self.json_entries_packed`
      **/
-    fn get_json_entry_unchecked_with_key_index<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> (JSONEntry, Field) {
+    fn get_json_entry_unchecked_with_key_index<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> (JSONEntry, Field) {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
 
         let hasher: ByteHasher<MaxKeyFields> = ByteHasher {};
@@ -118,11 +118,11 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief same as `get_json_entry_unchecked_var` but also returns the position of the JSONEntry in `self.json_entries_packed`
      **/
-    fn get_json_entry_unchecked_with_key_index_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> (JSONEntry, Field) {
+    fn get_json_entry_unchecked_with_key_index_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> (JSONEntry, Field) {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
 
         let hasher: ByteHasher<MaxKeyFields> = ByteHasher {};
-        let keyhash = hasher.get_keyhash_var(key.storage, 0, key.len as u16);
+        let keyhash = hasher.get_keyhash_var(key.storage, 0, key.len as u32);
         let two_pow_216 = 0x100000000000000000000000000000000000000000000000000000000;
 
         let keyhash = keyhash + self.root_id * two_pow_216;
@@ -139,7 +139,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      * @brief helper method that will extract an array of bytes that describes the value associated with a JSONEntry object
      * @description e.g. if the JSONEntry describes "foo" : "bar" in the JSON, `extract_string_entry` will return "foo"
      **/
-    fn extract_string_entry<let StringBytes: u16>(self, entry: JSONEntry) -> [u8; StringBytes] {
+    fn extract_string_entry<let StringBytes: u32>(self, entry: JSONEntry) -> [u8; StringBytes] {
         // todo can we make this faster? witness gen for this method is slow
         // TODO: document that StringBytes parameter includes non-escaped characters
         assert(
@@ -304,7 +304,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
     /**
      * @brief returns a bool that describes whether a given key exists at the root of the JSON
      **/
-    fn key_exists<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> bool {
+    fn key_exists<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> bool {
         self.key_exists_impl_var(key).0
     }
 
@@ -314,7 +314,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      *              Method computes a key hash and checks whether key hash exists in the list of sorted preprocessed key hashes
      *              If it does *not* exist, we can find two adjacent entries in `key_hashes` where `key_hashes[i]` < target_key_hash < `key_hashes[i+1]`
      **/
-    fn key_exists_impl<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> (bool, Field) {
+    fn key_exists_impl<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> (bool, Field) {
         /*
             Option A: key exists
             Option B: key does NOT exist
@@ -372,7 +372,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      *              Method computes a key hash and checks whether key hash exists in the list of sorted preprocessed key hashes
      *              If it does *not* exist, we can find two adjacent entries in `key_hashes` where `key_hashes[i]` < target_key_hash < `key_hashes[i+1]`
      **/
-    fn key_exists_impl_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> (bool, Field) {
+    fn key_exists_impl_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> (bool, Field) {
         /*
             Option A: key exists
             Option B: key does NOT exist
@@ -384,7 +384,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
 
         */
         let hasher: ByteHasher<MaxKeyFields> = ByteHasher {};
-        let keyhash = hasher.get_keyhash_var(key.storage, 0, key.len as u16);
+        let keyhash = hasher.get_keyhash_var(key.storage, 0, key.len as u32);
 
         let HASH_MAXIMUM = 0x1000000000000000000000000000000000000000000000000000000000000 - 1;
         let two_pow_216 = 0x100000000000000000000000000000000000000000000000000000000;
@@ -424,7 +424,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
         (search_result.found, search_result.lhs_index)
     }
 
-    unconstrained fn __get_keys_at_root<let MaxNumKeys: u16>(self) -> BoundedVec<Field, MaxNumKeys> {
+    unconstrained fn __get_keys_at_root<let MaxNumKeys: u32>(self) -> BoundedVec<Field, MaxNumKeys> {
         let mut result: BoundedVec<Field, MaxNumKeys> = BoundedVec { len: 0, storage: [0; MaxNumKeys] };
 
         let root_object: JSONEntry = JSONEntry::from(self.json_entries_packed[self.root_index_in_transcript]);
@@ -441,7 +441,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
         result.len = result_ptr as u32;
         result
     }
-    fn get_keys_at_root<let MaxNumKeys: u16, let MaxKeyBytes: u16>(self) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
+    fn get_keys_at_root<let MaxNumKeys: u32, let MaxKeyBytes: u32>(self) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
         let root_object: JSONEntry = JSONEntry::from(self.json_entries_packed[self.root_index_in_transcript]);
         let key_indices: BoundedVec<Field, MaxNumKeys> = self.__get_keys_at_root();
 

--- a/src/json.nr
+++ b/src/json.nr
@@ -40,12 +40,12 @@ impl<let MaxLength: u32> JSONValue<MaxLength> {
  * @description The "root" of the JSON refers to the parent object or array (or a value if the json is just a single value e.g. text = "\"foo\": \"bar\"")
  * @note text that describes just a single JSON value is not yet fully supported. Only use this library for processing objects or arrays for now
  **/
-struct JSON<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let MaxNumValues: u16, let MaxKeyFields: u16> {
+struct JSON<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let MaxNumValues: u32, let MaxKeyFields: u32> {
     json: [u8; NumBytes], // the raw json bytes
     json_packed: [Field; NumPackedFields], // raw bytes, but packed into 31-byte Field elements
     raw_transcript: [Field; MaxNumTokens], // transcript of json tokens after basic processing
     transcript: [Field; MaxNumTokens], // complete transcript of json tokens
-    transcript_length: u16, // how big is the transcript?
+    transcript_length: u32, // how big is the transcript?
     key_data: [Field; MaxNumValues], // description of each key, packed into a Field element
     key_hashes: [Field; MaxNumValues], // a sorted list of key hashes
     unsorted_json_entries_packed: [JSONEntryPacked; MaxNumValues], // a list of all the processed json values (objects, arrays, numerics, literals, strings)
@@ -59,7 +59,7 @@ struct JSON<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, 
  * @brief are two JSON objects equal?
  * @note VERY EXPENSIVE! Currently only used in tests
  **/
-impl<let NumBytes: u16, let NumPackedFields: u16, let MaxNumTokens: u16, let MaxNumValues: u16, let MaxKeyFields: u16> std::cmp::Eq for JSON<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
+impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let MaxNumValues: u32, let MaxKeyFields: u32> std::cmp::Eq for JSON<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
     fn eq(self, other: Self) -> bool {
         (self.json == other.json)
             & (self.raw_transcript == other.raw_transcript)
@@ -77,12 +77,12 @@ impl<let NumBytes: u16, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
 }
 
 // TODO: casting entry_ptr to u16 is kind of expensive when generating witnesses, can we fix?
-unconstrained fn __check_entry_ptr_bounds(entry_ptr: Field, max: u16) {
+unconstrained fn __check_entry_ptr_bounds(entry_ptr: Field, max: u32) {
     // n.b. even though this assert is in an unconstrained function, an out of bounds error will be triggered when writing into self.key_data[entry_ptr]
-    assert(entry_ptr as u16 < max - 1, "create_json_entries: MaxNumValues limit exceeded!");
+    assert(entry_ptr as u32 < max - 1, "create_json_entries: MaxNumValues limit exceeded!");
 }
 
-impl<let NumBytes: u16, let NumPackedFields: u16, let MaxNumTokens: u16, let MaxNumValues: u16, let MaxKeyFields: u16> JSON<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
+impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let MaxNumValues: u32, let MaxKeyFields: u32> JSON<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
 
     /**
      * @brief pack the json bytes into Field elements, where each Field element represents 31 bytes
@@ -112,7 +112,7 @@ impl<let NumBytes: u16, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
             limb *= 0x100;
         }
         std::as_witness(limb);
-        self.json_packed[NumWholeLimbs + (NumRemainingBytes == 0) as u16] = limb;
+        self.json_packed[NumWholeLimbs + (NumRemainingBytes == 0) as u32] = limb;
     }
 
     // TODO: when impl is more mature, merge this into create_json_entries
@@ -182,7 +182,7 @@ impl<let NumBytes: u16, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
             let current_token = tokens[i];
 
             // 1 gate
-            let index = current_layer * NN + previous_token * NUM_TOKENS + current_token;
+            let index = current_layer * (NN as Field) + previous_token * (NUM_TOKENS as Field) + current_token;
 
             // 5 gates
             let  ValidationFlags{push_layer, push_layer_type_of_root, pop_layer} = ValidationFlags::from_field(TOKEN_VALIDATION_TABLE[index]);
@@ -256,7 +256,7 @@ impl<let NumBytes: u16, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
                 is_key_token: update_key,
                 is_value_token,
                 preserve_num_entries
-            } = TokenFlags::from_field(TOKEN_FLAGS_TABLE[token + context * NUM_TOKENS]);
+            } = TokenFlags::from_field(TOKEN_FLAGS_TABLE[token + context * (NUM_TOKENS as Field)]);
 
             // 2 gates
             let diff = (index + length * 0x10000) - current_key_index_and_length;
@@ -380,7 +380,7 @@ impl<let NumBytes: u16, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      **/
     unconstrained fn __build_transcript(self) -> [Field; MaxNumTokens] {
         let mut raw_transcript: [Field; MaxNumTokens] = [0; MaxNumTokens];
-        let mut transcript_ptr: u16 = 0;
+        let mut transcript_ptr: u32 = 0;
         let mut scan_mode = GRAMMAR_SCAN as Field;
         let mut length: Field = 0;
         let mut previous_was_potential_escape_sequence = 0;
@@ -399,7 +399,7 @@ impl<let NumBytes: u16, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
 
             raw_transcript[transcript_ptr] = new_entry;
             length = length * (1 - push_transcript) + increase_length;
-            transcript_ptr += (push_transcript as bool) as u16;
+            transcript_ptr += (push_transcript as bool) as u32;
 
             previous_was_potential_escape_sequence = is_potential_escape_sequence;
 
@@ -486,7 +486,7 @@ impl<let NumBytes: u16, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
             json: self.json,
             raw_transcript,
             transcript: self.transcript,
-            transcript_length: transcript_ptr as u16,
+            transcript_length: transcript_ptr as u32,
             key_data: self.key_data,
             key_hashes: self.key_hashes,
             layer_type_of_root: self.layer_type_of_root,
@@ -504,7 +504,7 @@ impl<let NumBytes: u16, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
      **/
     unconstrained fn __capture_missing_tokens(self) -> [Field; MaxNumTokens] {
         let mut updated_transcript: [Field; MaxNumTokens] = [0; MaxNumTokens];
-        let mut transcript_ptr: u16 = 0;
+        let mut transcript_ptr: u32 = 0;
         // TODO: do we need a null transcript value?!?!
 
         for i in 0..MaxNumTokens {
@@ -515,7 +515,7 @@ impl<let NumBytes: u16, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
             let entry = TranscriptEntry::to_field(TranscriptEntry { token, index, length });
             updated_transcript[transcript_ptr] = entry;
 
-            let index_valid: u16 = (i < self.transcript_length) as u16;
+            let index_valid: u32 = (i < self.transcript_length) as u32;
             transcript_ptr += index_valid;
 
             let index_of_possible_grammar = (index + length);
@@ -525,7 +525,7 @@ impl<let NumBytes: u16, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
             let new_transcript = TranscriptEntry::to_field(new_entry);
             assert(transcript_ptr < MaxNumTokens, "capture_missing_tokens: MaxNumTokens limit exceeded!");
             updated_transcript[transcript_ptr] = new_transcript;
-            transcript_ptr += update as bool as u16;
+            transcript_ptr += update as bool as u32;
         }
         updated_transcript
     }
@@ -582,11 +582,11 @@ impl<let NumBytes: u16, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
         } else if (first.token == BEGIN_ARRAY_TOKEN) {
             self.layer_type_of_root = ARRAY_LAYER;
         } else if (first.token == STRING_TOKEN) {
-            self.layer_type_of_root = SINGLE_VALUE_LAYER;
+            self.layer_type_of_root = SINGLE_VALUE_LAYER as Field;
         }
     }
 
-    fn parse_json<let StringBytes: u16>(stringbytes: [u8; StringBytes]) -> Self {
+    fn parse_json<let StringBytes: u32>(stringbytes: [u8; StringBytes]) -> Self {
         assert(StringBytes <= NumBytes, "json length exceeds NumBytes!");
         let mut text: [u8; NumBytes] = [0; NumBytes];
         for i in 0..StringBytes {
@@ -621,7 +621,7 @@ impl<let NumBytes: u16, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
         json
     }
 
-    fn parse_json_from_string<let StringBytes: u16>(s: str<StringBytes>) -> Self {
+    fn parse_json_from_string<let StringBytes: u32>(s: str<StringBytes>) -> Self {
         JSON::parse_json(s.as_bytes())
     }
 }

--- a/src/keyhash.nr
+++ b/src/keyhash.nr
@@ -6,12 +6,12 @@ use crate::_string_tools::slice_field::slice_200_bits_from_field;
  *        when the bytes are represented as packed 31 byte Field elements
  * @note we wrap `get_keyhash` in a struct so that the KeyFields parameter can be defined ahead of time
  **/
-struct FieldHasher<let KeyFields: u16>
+struct FieldHasher<let KeyFields: u32>
 {}
 
-impl<let KeyFields: u16> FieldHasher<KeyFields> {
+impl<let KeyFields: u32> FieldHasher<KeyFields> {
 
-    fn get_keyhash<let NumPackedFields: u16>(
+    fn get_keyhash<let NumPackedFields: u32>(
         _: Self,
         packed_fields: [Field; NumPackedFields],
         body_index: Field,
@@ -29,22 +29,22 @@ impl<let KeyFields: u16> FieldHasher<KeyFields> {
  * @note we wrap `get_keyhash` in a struct so that the KeyFields parameter can be defined ahead of time
  * @note produces identical hash outputs when compared w. FieldHasher
  **/
-struct ByteHasher<let KeyFields: u16>
+struct ByteHasher<let KeyFields: u32>
 {}
 
-impl<let KeyFields: u16> ByteHasher<KeyFields> {
+impl<let KeyFields: u32> ByteHasher<KeyFields> {
 
     fn get_keyhash_var<let N: u32>(
         _: Self,
         body_text: [u8; N],
-        body_index: u16,
-        key_length: u16
+        body_index: u32,
+        key_length: u32
     ) -> Field {
         assert(key_length < KeyFields * 31, "key too large");
 
         let mut key_fields: [Field; KeyFields] = [0; KeyFields];
 
-        let mut key_idx: u16 = 0;
+        let mut key_idx: u32 = 0;
         let mut limb = 0;
 
         for j in 0..KeyFields {

--- a/src/keymap.nr
+++ b/src/keymap.nr
@@ -45,7 +45,7 @@ impl KeyIndexData {
     }
 }
 
-impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let MaxNumValues: u16, let MaxKeyFields: u16> JSON<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
+impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let MaxNumValues: u32, let MaxKeyFields: u32> JSON<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields> {
     fn compute_keyhash_and_sort_json_entries(&mut self) {
         let hasher: FieldHasher<MaxKeyFields> = FieldHasher {};
 
@@ -107,7 +107,7 @@ impl<let NumBytes: u32, let NumPackedFields: u16, let MaxNumTokens: u16, let Max
             // n.b. parent_identity_post - parent_identity_pre is not neccessarily 0 or 1 (can be larger)
             //      due to empty objects and arrays increasing identity value without creating associated child json entries
             let new_parent = lt_field_16_bit(parent_identity_pre, parent_identity_post) as Field;
-            // let new_parent = (parent_identity_post as u16 > parent_identity_pre as u16) as Field;
+            // let new_parent = (parent_identity_post as u32 > parent_identity_pre as u32) as Field;
             // 3.5 gates
             let index_of_parent = identity_to_json_map[parent_identity_post];
             // 1 gate + 3.5 gates

--- a/src/lib.nr
+++ b/src/lib.nr
@@ -25,50 +25,50 @@ use crate::get_literal::JSONLiteral;
 
 trait JSONParserTrait
 {
-    fn parse_json_from_string<let StringBytes: u16>(s: str<StringBytes>) -> Self;
-    fn parse_json<let StringBytes: u16>(s: [u8; StringBytes]) -> Self;
+    fn parse_json_from_string<let StringBytes: u32>(s: str<StringBytes>) -> Self;
+    fn parse_json<let StringBytes: u32>(s: [u8; StringBytes]) -> Self;
     fn get_length(self) -> u32;
-    fn get_array<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<Self>;
-    fn get_array_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Self;
-    fn get_array_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self>;
-    fn get_array_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Self;
+    fn get_array<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self>;
+    fn get_array_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self;
+    fn get_array_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self>;
+    fn get_array_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self;
     fn get_array_from_array(self, array_index: Field) -> Option<Self>;
     fn get_array_from_array_unchecked(self, array_index: Field) -> Self;
     fn map<U, let MaxElements: u32, let MaxElementBytes: u32>(self, f: fn(JSONValue<MaxElementBytes>) -> U) -> [U; MaxElements] where U: std::default::Default;
-    fn get_object<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<Self>;
-    fn get_object_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Self;
-    fn get_object_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self>;
-    fn get_object_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Self;
+    fn get_object<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self>;
+    fn get_object_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self;
+    fn get_object_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self>;
+    fn get_object_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self;
     fn get_object_from_array(self, array_index: Field) -> Option<Self>;
     fn get_object_from_array_unchecked(self, array_index: Field) -> Self;
-    fn get_literal<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<JSONLiteral>;
-    fn get_literal_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> JSONLiteral;
-    fn get_literal_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<JSONLiteral>;
-    fn get_literal_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> JSONLiteral;
+    fn get_literal<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<JSONLiteral>;
+    fn get_literal_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> JSONLiteral;
+    fn get_literal_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<JSONLiteral>;
+    fn get_literal_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> JSONLiteral;
     fn get_literal_from_array(self, array_index: Field) -> Option<JSONLiteral>;
     fn get_literal_from_array_unchecked(self, array_index: Field) -> JSONLiteral;
-    fn get_number<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<u64>;
-    fn get_number_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> u64;
-    fn get_number_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64>;
-    fn get_number_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> u64;
+    fn get_number<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<u64>;
+    fn get_number_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> u64;
+    fn get_number_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64>;
+    fn get_number_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> u64;
     fn get_number_from_array(self, array_index: Field) -> Option<u64>;
     fn get_number_from_array_unchecked(self, array_index: Field) -> u64;
-    fn get_string<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> Option<BoundedVec<u8, StringBytes>>;
-    fn get_string_unchecked<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> BoundedVec<u8, StringBytes>;
-    fn get_string_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<BoundedVec<u8, StringBytes>>;
-    fn get_string_unchecked_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> BoundedVec<u8, StringBytes>;
-    fn get_string_from_array<let StringBytes: u16>(self, array_index: Field) -> Option<BoundedVec<u8, StringBytes>>;
-    fn get_string_from_array_unchecked<let StringBytes: u16>(self, array_index: Field) -> BoundedVec<u8, StringBytes>;
-    fn get_string_from_path<let KeyBytes: u16, let StringBytes: u16, let PathDepth: u16>(self, keys: [BoundedVec<u8, KeyBytes>; PathDepth]) -> Option<BoundedVec<u8, StringBytes>>;
-    fn get_value<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> Option<JSONValue<StringBytes>>;
-    fn get_value_unchecked<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> JSONValue<StringBytes>;
-    fn get_value_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<JSONValue<StringBytes>>;
-    fn get_value_unchecked_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> JSONValue<StringBytes>;
-    fn get_value_from_array<let StringBytes: u16>(self, array_index: Field) -> Option<JSONValue<StringBytes>>;
-    fn get_value_from_array_unchecked<let StringBytes: u16>(self, array_index: Field) -> JSONValue<StringBytes>;
-    fn get_value_from_path<let KeyBytes: u16, let StringBytes: u16, let PathDepth: u16>(self,keys: [BoundedVec<u8, KeyBytes>; PathDepth]) -> Option<JSONValue<StringBytes>>;
-    fn key_exists<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> bool;
-    fn get_keys_at_root<let MaxNumKeys: u16, let MaxKeyBytes: u16>(self) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys>;
+    fn get_string<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> Option<BoundedVec<u8, StringBytes>>;
+    fn get_string_unchecked<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> BoundedVec<u8, StringBytes>;
+    fn get_string_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<BoundedVec<u8, StringBytes>>;
+    fn get_string_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> BoundedVec<u8, StringBytes>;
+    fn get_string_from_array<let StringBytes: u32>(self, array_index: Field) -> Option<BoundedVec<u8, StringBytes>>;
+    fn get_string_from_array_unchecked<let StringBytes: u32>(self, array_index: Field) -> BoundedVec<u8, StringBytes>;
+    fn get_string_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(self, keys: [BoundedVec<u8, KeyBytes>; PathDepth]) -> Option<BoundedVec<u8, StringBytes>>;
+    fn get_value<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> Option<JSONValue<StringBytes>>;
+    fn get_value_unchecked<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> JSONValue<StringBytes>;
+    fn get_value_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<JSONValue<StringBytes>>;
+    fn get_value_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> JSONValue<StringBytes>;
+    fn get_value_from_array<let StringBytes: u32>(self, array_index: Field) -> Option<JSONValue<StringBytes>>;
+    fn get_value_from_array_unchecked<let StringBytes: u32>(self, array_index: Field) -> JSONValue<StringBytes>;
+    fn get_value_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(self,keys: [BoundedVec<u8, KeyBytes>; PathDepth]) -> Option<JSONValue<StringBytes>>;
+    fn key_exists<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> bool;
+    fn get_keys_at_root<let MaxNumKeys: u32, let MaxKeyBytes: u32>(self) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys>;
 }
 
 mod JSON512b {
@@ -83,28 +83,28 @@ mod JSON512b {
         }
     }
     impl crate::JSONParserTrait for JSON {
-        fn parse_json_from_string<let StringBytes: u16>(s: str<StringBytes>) -> Self {
+        fn parse_json_from_string<let StringBytes: u32>(s: str<StringBytes>) -> Self {
             JSON { inner: crate::json::JSON::parse_json_from_string(s) }
         }
 
-        fn parse_json<let StringBytes: u16>(s: [u8; StringBytes]) -> Self {
+        fn parse_json<let StringBytes: u32>(s: [u8; StringBytes]) -> Self {
             JSON { inner: crate::json::JSON::parse_json(s) }
         }
         fn get_length(self) -> u32 {
             self.inner.get_length()
         }
-        fn get_array<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<Self> {
+        fn get_array<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
             JSON::convert(self.inner.get_array(key))
         }
-        fn get_array_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Self {
+        fn get_array_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
             JSON { inner: self.inner.get_array_unchecked(key) }
         }
-        fn get_array_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+        fn get_array_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_array_var(key))
             }
         }
-        fn get_array_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
+        fn get_array_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
             JSON { inner: self.inner.get_array_unchecked_var(key) }
         }
         fn get_array_from_array(self, array_index: Field) -> Option<Self> {
@@ -119,20 +119,20 @@ mod JSON512b {
         ) -> [U; MaxElements] where U: std::default::Default {
             self.inner.map(f)
         }
-        fn get_object<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<Self> {
+        fn get_object<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_object(key))
             }
         }
-        fn get_object_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Self {
+        fn get_object_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
             JSON { inner: self.inner.get_object_unchecked(key) }
         }
-        fn get_object_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+        fn get_object_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_object_var(key))
             }
         }
-        fn get_object_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
+        fn get_object_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
             JSON { inner: self.inner.get_object_unchecked_var(key) }
         }
         fn get_object_from_array(self, array_index: Field) -> Option<Self> {
@@ -141,16 +141,16 @@ mod JSON512b {
         fn get_object_from_array_unchecked(self, array_index: Field) -> Self {
             JSON { inner: self.inner.get_object_from_array_unchecked(array_index) }
         }
-        fn get_literal<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<crate::JSONLiteral> {
+        fn get_literal<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<crate::JSONLiteral> {
             self.inner.get_literal(key)
         }
-        fn get_literal_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> crate::JSONLiteral {
+        fn get_literal_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> crate::JSONLiteral {
             self.inner.get_literal_unchecked(key)
         }
-        fn get_literal_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONLiteral> {
+        fn get_literal_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONLiteral> {
             self.inner.get_literal_var(key)
         }
-        fn get_literal_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONLiteral {
+        fn get_literal_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONLiteral {
             self.inner.get_literal_unchecked_var(key)
         }
         fn get_literal_from_array(self, array_index: Field) -> Option<crate::JSONLiteral> {
@@ -159,16 +159,16 @@ mod JSON512b {
         fn get_literal_from_array_unchecked(self, array_index: Field) -> crate::JSONLiteral {
             self.inner.get_literal_from_array_unchecked(array_index)
         }
-        fn get_number<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<u64> {
+        fn get_number<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<u64> {
             self.inner.get_number(key)
         }
-        fn get_number_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> u64 {
+        fn get_number_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> u64 {
             self.inner.get_number_unchecked(key)
         }
-        fn get_number_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64> {
+        fn get_number_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64> {
             self.inner.get_number_var(key)
         }
-        fn get_number_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> u64 {
+        fn get_number_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> u64 {
             self.inner.get_number_unchecked_var(key)
         }
         fn get_number_from_array(self, array_index: Field) -> Option<u64> {
@@ -178,59 +178,59 @@ mod JSON512b {
             self.inner.get_number_from_array_unchecked(array_index)
         }
 
-        fn get_string<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string(key)
         }
-        fn get_string_unchecked<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> BoundedVec<u8, StringBytes> {
+        fn get_string_unchecked<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_unchecked(key)
         }
-        fn get_string_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_var(key)
         }
-        fn get_string_unchecked_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> BoundedVec<u8, StringBytes> {
+        fn get_string_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_unchecked_var(key)
         }
-        fn get_string_from_array<let StringBytes: u16>(self, array_index: Field) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string_from_array<let StringBytes: u32>(self, array_index: Field) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_from_array(array_index)
         }
-        fn get_string_from_array_unchecked<let StringBytes: u16>(self, array_index: Field) -> BoundedVec<u8, StringBytes> {
+        fn get_string_from_array_unchecked<let StringBytes: u32>(self, array_index: Field) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_from_array_unchecked(array_index)
         }
-        fn get_string_from_path<let KeyBytes: u16, let StringBytes: u16, let PathDepth: u16>(
+        fn get_string_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
             self,
             keys: [BoundedVec<u8, KeyBytes>; PathDepth]
         ) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_from_path(keys)
         }
-        fn get_value<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value(key)
         }
-        fn get_value_unchecked<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> crate::JSONValue<StringBytes> {
+        fn get_value_unchecked<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_unchecked(key)
         }
-        fn get_value_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_var(key)
         }
-        fn get_value_unchecked_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONValue<StringBytes> {
+        fn get_value_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_unchecked_var(key)
         }
-        fn get_value_from_array<let StringBytes: u16>(self, array_index: Field) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value_from_array<let StringBytes: u32>(self, array_index: Field) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_from_array(array_index)
         }
-        fn get_value_from_array_unchecked<let StringBytes: u16>(self, array_index: Field) -> crate::JSONValue<StringBytes> {
+        fn get_value_from_array_unchecked<let StringBytes: u32>(self, array_index: Field) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_from_array_unchecked(array_index)
         }
-        fn get_value_from_path<let KeyBytes: u16, let StringBytes: u16, let PathDepth: u16>(
+        fn get_value_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
             self,
             keys: [BoundedVec<u8, KeyBytes>; PathDepth]
         ) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_from_path(keys)
         }
 
-        fn key_exists<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> bool {
+        fn key_exists<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> bool {
             self.inner.key_exists(key)
         }
-        fn get_keys_at_root<let MaxNumKeys: u16, let MaxKeyBytes: u16>(self) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
+        fn get_keys_at_root<let MaxNumKeys: u32, let MaxKeyBytes: u32>(self) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
             self.inner.get_keys_at_root()
         }
     }
@@ -247,28 +247,28 @@ mod JSON1kb {
         }
     }
     impl crate::JSONParserTrait for JSON {
-        fn parse_json_from_string<let StringBytes: u16>(s: str<StringBytes>) -> Self {
+        fn parse_json_from_string<let StringBytes: u32>(s: str<StringBytes>) -> Self {
             JSON { inner: crate::json::JSON::parse_json_from_string(s) }
         }
 
-        fn parse_json<let StringBytes: u16>(s: [u8; StringBytes]) -> Self {
+        fn parse_json<let StringBytes: u32>(s: [u8; StringBytes]) -> Self {
             JSON { inner: crate::json::JSON::parse_json(s) }
         }
         fn get_length(self) -> u32 {
             self.inner.get_length()
         }
-        fn get_array<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<Self> {
+        fn get_array<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
             JSON::convert(self.inner.get_array(key))
         }
-        fn get_array_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Self {
+        fn get_array_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
             JSON { inner: self.inner.get_array_unchecked(key) }
         }
-        fn get_array_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+        fn get_array_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_array_var(key))
             }
         }
-        fn get_array_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
+        fn get_array_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
             JSON { inner: self.inner.get_array_unchecked_var(key) }
         }
         fn get_array_from_array(self, array_index: Field) -> Option<Self> {
@@ -283,20 +283,20 @@ mod JSON1kb {
         ) -> [U; MaxElements] where U: std::default::Default {
             self.inner.map(f)
         }
-        fn get_object<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<Self> {
+        fn get_object<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_object(key))
             }
         }
-        fn get_object_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Self {
+        fn get_object_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
             JSON { inner: self.inner.get_object_unchecked(key) }
         }
-        fn get_object_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+        fn get_object_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_object_var(key))
             }
         }
-        fn get_object_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
+        fn get_object_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
             JSON { inner: self.inner.get_object_unchecked_var(key) }
         }
         fn get_object_from_array(self, array_index: Field) -> Option<Self> {
@@ -305,16 +305,16 @@ mod JSON1kb {
         fn get_object_from_array_unchecked(self, array_index: Field) -> Self {
             JSON { inner: self.inner.get_object_from_array_unchecked(array_index) }
         }
-        fn get_literal<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<crate::JSONLiteral> {
+        fn get_literal<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<crate::JSONLiteral> {
             self.inner.get_literal(key)
         }
-        fn get_literal_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> crate::JSONLiteral {
+        fn get_literal_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> crate::JSONLiteral {
             self.inner.get_literal_unchecked(key)
         }
-        fn get_literal_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONLiteral> {
+        fn get_literal_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONLiteral> {
             self.inner.get_literal_var(key)
         }
-        fn get_literal_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONLiteral {
+        fn get_literal_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONLiteral {
             self.inner.get_literal_unchecked_var(key)
         }
         fn get_literal_from_array(self, array_index: Field) -> Option<crate::JSONLiteral> {
@@ -323,16 +323,16 @@ mod JSON1kb {
         fn get_literal_from_array_unchecked(self, array_index: Field) -> crate::JSONLiteral {
             self.inner.get_literal_from_array_unchecked(array_index)
         }
-        fn get_number<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<u64> {
+        fn get_number<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<u64> {
             self.inner.get_number(key)
         }
-        fn get_number_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> u64 {
+        fn get_number_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> u64 {
             self.inner.get_number_unchecked(key)
         }
-        fn get_number_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64> {
+        fn get_number_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64> {
             self.inner.get_number_var(key)
         }
-        fn get_number_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> u64 {
+        fn get_number_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> u64 {
             self.inner.get_number_unchecked_var(key)
         }
         fn get_number_from_array(self, array_index: Field) -> Option<u64> {
@@ -341,58 +341,58 @@ mod JSON1kb {
         fn get_number_from_array_unchecked(self, array_index: Field) -> u64 {
             self.inner.get_number_from_array_unchecked(array_index)
         }
-        fn get_string<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string(key)
         }
-        fn get_string_unchecked<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> BoundedVec<u8, StringBytes> {
+        fn get_string_unchecked<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_unchecked(key)
         }
-        fn get_string_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_var(key)
         }
-        fn get_string_unchecked_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> BoundedVec<u8, StringBytes> {
+        fn get_string_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_unchecked_var(key)
         }
-        fn get_string_from_array<let StringBytes: u16>(self, array_index: Field) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string_from_array<let StringBytes: u32>(self, array_index: Field) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_from_array(array_index)
         }
-        fn get_string_from_array_unchecked<let StringBytes: u16>(self, array_index: Field) -> BoundedVec<u8, StringBytes> {
+        fn get_string_from_array_unchecked<let StringBytes: u32>(self, array_index: Field) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_from_array_unchecked(array_index)
         }
-        fn get_string_from_path<let KeyBytes: u16, let StringBytes: u16, let PathDepth: u16>(
+        fn get_string_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
             self,
             keys: [BoundedVec<u8, KeyBytes>; PathDepth]
         ) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_from_path(keys)
         }
-        fn get_value<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value(key)
         }
-        fn get_value_unchecked<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> crate::JSONValue<StringBytes> {
+        fn get_value_unchecked<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_unchecked(key)
         }
-        fn get_value_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_var(key)
         }
-        fn get_value_unchecked_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONValue<StringBytes> {
+        fn get_value_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_unchecked_var(key)
         }
-        fn get_value_from_array<let StringBytes: u16>(self, array_index: Field) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value_from_array<let StringBytes: u32>(self, array_index: Field) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_from_array(array_index)
         }
-        fn get_value_from_array_unchecked<let StringBytes: u16>(self, array_index: Field) -> crate::JSONValue<StringBytes> {
+        fn get_value_from_array_unchecked<let StringBytes: u32>(self, array_index: Field) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_from_array_unchecked(array_index)
         }
-        fn get_value_from_path<let KeyBytes: u16, let StringBytes: u16, let PathDepth: u16>(
+        fn get_value_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
             self,
             keys: [BoundedVec<u8, KeyBytes>; PathDepth]
         ) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_from_path(keys)
         }
-        fn key_exists<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> bool {
+        fn key_exists<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> bool {
             self.inner.key_exists(key)
         }
-        fn get_keys_at_root<let MaxNumKeys: u16, let MaxKeyBytes: u16>(self) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
+        fn get_keys_at_root<let MaxNumKeys: u32, let MaxKeyBytes: u32>(self) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
             self.inner.get_keys_at_root()
         }
     }
@@ -409,28 +409,28 @@ mod JSON2kb {
         }
     }
     impl crate::JSONParserTrait for JSON {
-        fn parse_json_from_string<let StringBytes: u16>(s: str<StringBytes>) -> Self {
+        fn parse_json_from_string<let StringBytes: u32>(s: str<StringBytes>) -> Self {
             JSON { inner: crate::json::JSON::parse_json_from_string(s) }
         }
 
-        fn parse_json<let StringBytes: u16>(s: [u8; StringBytes]) -> Self {
+        fn parse_json<let StringBytes: u32>(s: [u8; StringBytes]) -> Self {
             JSON { inner: crate::json::JSON::parse_json(s) }
         }
         fn get_length(self) -> u32 {
             self.inner.get_length()
         }
-        fn get_array<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<Self> {
+        fn get_array<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
             JSON::convert(self.inner.get_array(key))
         }
-        fn get_array_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Self {
+        fn get_array_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
             JSON { inner: self.inner.get_array_unchecked(key) }
         }
-        fn get_array_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+        fn get_array_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_array_var(key))
             }
         }
-        fn get_array_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
+        fn get_array_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
             JSON { inner: self.inner.get_array_unchecked_var(key) }
         }
         fn get_array_from_array(self, array_index: Field) -> Option<Self> {
@@ -445,20 +445,20 @@ mod JSON2kb {
         ) -> [U; MaxElements] where U: std::default::Default {
             self.inner.map(f)
         }
-        fn get_object<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<Self> {
+        fn get_object<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_object(key))
             }
         }
-        fn get_object_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Self {
+        fn get_object_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
             JSON { inner: self.inner.get_object_unchecked(key) }
         }
-        fn get_object_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+        fn get_object_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_object_var(key))
             }
         }
-        fn get_object_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
+        fn get_object_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
             JSON { inner: self.inner.get_object_unchecked_var(key) }
         }
         fn get_object_from_array(self, array_index: Field) -> Option<Self> {
@@ -467,16 +467,16 @@ mod JSON2kb {
         fn get_object_from_array_unchecked(self, array_index: Field) -> Self {
             JSON { inner: self.inner.get_object_from_array_unchecked(array_index) }
         }
-        fn get_literal<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<crate::JSONLiteral> {
+        fn get_literal<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<crate::JSONLiteral> {
             self.inner.get_literal(key)
         }
-        fn get_literal_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> crate::JSONLiteral {
+        fn get_literal_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> crate::JSONLiteral {
             self.inner.get_literal_unchecked(key)
         }
-        fn get_literal_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONLiteral> {
+        fn get_literal_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONLiteral> {
             self.inner.get_literal_var(key)
         }
-        fn get_literal_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONLiteral {
+        fn get_literal_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONLiteral {
             self.inner.get_literal_unchecked_var(key)
         }
         fn get_literal_from_array(self, array_index: Field) -> Option<crate::JSONLiteral> {
@@ -485,16 +485,16 @@ mod JSON2kb {
         fn get_literal_from_array_unchecked(self, array_index: Field) -> crate::JSONLiteral {
             self.inner.get_literal_from_array_unchecked(array_index)
         }
-        fn get_number<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<u64> {
+        fn get_number<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<u64> {
             self.inner.get_number(key)
         }
-        fn get_number_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> u64 {
+        fn get_number_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> u64 {
             self.inner.get_number_unchecked(key)
         }
-        fn get_number_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64> {
+        fn get_number_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64> {
             self.inner.get_number_var(key)
         }
-        fn get_number_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> u64 {
+        fn get_number_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> u64 {
             self.inner.get_number_unchecked_var(key)
         }
         fn get_number_from_array(self, array_index: Field) -> Option<u64> {
@@ -503,58 +503,58 @@ mod JSON2kb {
         fn get_number_from_array_unchecked(self, array_index: Field) -> u64 {
             self.inner.get_number_from_array_unchecked(array_index)
         }
-        fn get_string<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string(key)
         }
-        fn get_string_unchecked<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> BoundedVec<u8, StringBytes> {
+        fn get_string_unchecked<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_unchecked(key)
         }
-        fn get_string_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_var(key)
         }
-        fn get_string_unchecked_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> BoundedVec<u8, StringBytes> {
+        fn get_string_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_unchecked_var(key)
         }
-        fn get_string_from_array<let StringBytes: u16>(self, array_index: Field) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string_from_array<let StringBytes: u32>(self, array_index: Field) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_from_array(array_index)
         }
-        fn get_string_from_array_unchecked<let StringBytes: u16>(self, array_index: Field) -> BoundedVec<u8, StringBytes> {
+        fn get_string_from_array_unchecked<let StringBytes: u32>(self, array_index: Field) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_from_array_unchecked(array_index)
         }
-        fn get_string_from_path<let KeyBytes: u16, let StringBytes: u16, let PathDepth: u16>(
+        fn get_string_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
             self,
             keys: [BoundedVec<u8, KeyBytes>; PathDepth]
         ) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_from_path(keys)
         }
-        fn get_value<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value(key)
         }
-        fn get_value_unchecked<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> crate::JSONValue<StringBytes> {
+        fn get_value_unchecked<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_unchecked(key)
         }
-        fn get_value_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_var(key)
         }
-        fn get_value_unchecked_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONValue<StringBytes> {
+        fn get_value_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_unchecked_var(key)
         }
-        fn get_value_from_array<let StringBytes: u16>(self, array_index: Field) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value_from_array<let StringBytes: u32>(self, array_index: Field) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_from_array(array_index)
         }
-        fn get_value_from_array_unchecked<let StringBytes: u16>(self, array_index: Field) -> crate::JSONValue<StringBytes> {
+        fn get_value_from_array_unchecked<let StringBytes: u32>(self, array_index: Field) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_from_array_unchecked(array_index)
         }
-        fn get_value_from_path<let KeyBytes: u16, let StringBytes: u16, let PathDepth: u16>(
+        fn get_value_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
             self,
             keys: [BoundedVec<u8, KeyBytes>; PathDepth]
         ) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_from_path(keys)
         }
-        fn key_exists<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> bool {
+        fn key_exists<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> bool {
             self.inner.key_exists(key)
         }
-        fn get_keys_at_root<let MaxNumKeys: u16, let MaxKeyBytes: u16>(self) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
+        fn get_keys_at_root<let MaxNumKeys: u32, let MaxKeyBytes: u32>(self) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
             self.inner.get_keys_at_root()
         }
     }
@@ -571,28 +571,28 @@ mod JSON4kb {
         }
     }
     impl crate::JSONParserTrait for JSON {
-        fn parse_json_from_string<let StringBytes: u16>(s: str<StringBytes>) -> Self {
+        fn parse_json_from_string<let StringBytes: u32>(s: str<StringBytes>) -> Self {
             JSON { inner: crate::json::JSON::parse_json_from_string(s) }
         }
 
-        fn parse_json<let StringBytes: u16>(s: [u8; StringBytes]) -> Self {
+        fn parse_json<let StringBytes: u32>(s: [u8; StringBytes]) -> Self {
             JSON { inner: crate::json::JSON::parse_json(s) }
         }
         fn get_length(self) -> u32 {
             self.inner.get_length()
         }
-        fn get_array<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<Self> {
+        fn get_array<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
             JSON::convert(self.inner.get_array(key))
         }
-        fn get_array_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Self {
+        fn get_array_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
             JSON { inner: self.inner.get_array_unchecked(key) }
         }
-        fn get_array_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+        fn get_array_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_array_var(key))
             }
         }
-        fn get_array_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
+        fn get_array_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
             JSON { inner: self.inner.get_array_unchecked_var(key) }
         }
         fn get_array_from_array(self, array_index: Field) -> Option<Self> {
@@ -607,20 +607,20 @@ mod JSON4kb {
         ) -> [U; MaxElements] where U: std::default::Default {
             self.inner.map(f)
         }
-        fn get_object<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<Self> {
+        fn get_object<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_object(key))
             }
         }
-        fn get_object_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Self {
+        fn get_object_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
             JSON { inner: self.inner.get_object_unchecked(key) }
         }
-        fn get_object_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+        fn get_object_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_object_var(key))
             }
         }
-        fn get_object_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
+        fn get_object_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
             JSON { inner: self.inner.get_object_unchecked_var(key) }
         }
         fn get_object_from_array(self, array_index: Field) -> Option<Self> {
@@ -629,16 +629,16 @@ mod JSON4kb {
         fn get_object_from_array_unchecked(self, array_index: Field) -> Self {
             JSON { inner: self.inner.get_object_from_array_unchecked(array_index) }
         }
-        fn get_literal<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<crate::JSONLiteral> {
+        fn get_literal<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<crate::JSONLiteral> {
             self.inner.get_literal(key)
         }
-        fn get_literal_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> crate::JSONLiteral {
+        fn get_literal_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> crate::JSONLiteral {
             self.inner.get_literal_unchecked(key)
         }
-        fn get_literal_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONLiteral> {
+        fn get_literal_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONLiteral> {
             self.inner.get_literal_var(key)
         }
-        fn get_literal_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONLiteral {
+        fn get_literal_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONLiteral {
             self.inner.get_literal_unchecked_var(key)
         }
         fn get_literal_from_array(self, array_index: Field) -> Option<crate::JSONLiteral> {
@@ -647,16 +647,16 @@ mod JSON4kb {
         fn get_literal_from_array_unchecked(self, array_index: Field) -> crate::JSONLiteral {
             self.inner.get_literal_from_array_unchecked(array_index)
         }
-        fn get_number<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<u64> {
+        fn get_number<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<u64> {
             self.inner.get_number(key)
         }
-        fn get_number_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> u64 {
+        fn get_number_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> u64 {
             self.inner.get_number_unchecked(key)
         }
-        fn get_number_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64> {
+        fn get_number_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64> {
             self.inner.get_number_var(key)
         }
-        fn get_number_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> u64 {
+        fn get_number_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> u64 {
             self.inner.get_number_unchecked_var(key)
         }
         fn get_number_from_array(self, array_index: Field) -> Option<u64> {
@@ -665,58 +665,58 @@ mod JSON4kb {
         fn get_number_from_array_unchecked(self, array_index: Field) -> u64 {
             self.inner.get_number_from_array_unchecked(array_index)
         }
-        fn get_string<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string(key)
         }
-        fn get_string_unchecked<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> BoundedVec<u8, StringBytes> {
+        fn get_string_unchecked<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_unchecked(key)
         }
-        fn get_string_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_var(key)
         }
-        fn get_string_unchecked_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> BoundedVec<u8, StringBytes> {
+        fn get_string_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_unchecked_var(key)
         }
-        fn get_string_from_array<let StringBytes: u16>(self, array_index: Field) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string_from_array<let StringBytes: u32>(self, array_index: Field) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_from_array(array_index)
         }
-        fn get_string_from_array_unchecked<let StringBytes: u16>(self, array_index: Field) -> BoundedVec<u8, StringBytes> {
+        fn get_string_from_array_unchecked<let StringBytes: u32>(self, array_index: Field) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_from_array_unchecked(array_index)
         }
-        fn get_string_from_path<let KeyBytes: u16, let StringBytes: u16, let PathDepth: u16>(
+        fn get_string_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
             self,
             keys: [BoundedVec<u8, KeyBytes>; PathDepth]
         ) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_from_path(keys)
         }
-        fn get_value<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value(key)
         }
-        fn get_value_unchecked<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> crate::JSONValue<StringBytes> {
+        fn get_value_unchecked<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_unchecked(key)
         }
-        fn get_value_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_var(key)
         }
-        fn get_value_unchecked_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONValue<StringBytes> {
+        fn get_value_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_unchecked_var(key)
         }
-        fn get_value_from_array<let StringBytes: u16>(self, array_index: Field) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value_from_array<let StringBytes: u32>(self, array_index: Field) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_from_array(array_index)
         }
-        fn get_value_from_array_unchecked<let StringBytes: u16>(self, array_index: Field) -> crate::JSONValue<StringBytes> {
+        fn get_value_from_array_unchecked<let StringBytes: u32>(self, array_index: Field) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_from_array_unchecked(array_index)
         }
-        fn get_value_from_path<let KeyBytes: u16, let StringBytes: u16, let PathDepth: u16>(
+        fn get_value_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
             self,
             keys: [BoundedVec<u8, KeyBytes>; PathDepth]
         ) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_from_path(keys)
         }
-        fn key_exists<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> bool {
+        fn key_exists<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> bool {
             self.inner.key_exists(key)
         }
-        fn get_keys_at_root<let MaxNumKeys: u16, let MaxKeyBytes: u16>(self) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
+        fn get_keys_at_root<let MaxNumKeys: u32, let MaxKeyBytes: u32>(self) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
             self.inner.get_keys_at_root()
         }
     }
@@ -733,28 +733,28 @@ mod JSON8kb {
         }
     }
     impl crate::JSONParserTrait for JSON {
-        fn parse_json_from_string<let StringBytes: u16>(s: str<StringBytes>) -> Self {
+        fn parse_json_from_string<let StringBytes: u32>(s: str<StringBytes>) -> Self {
             JSON { inner: crate::json::JSON::parse_json_from_string(s) }
         }
 
-        fn parse_json<let StringBytes: u16>(s: [u8; StringBytes]) -> Self {
+        fn parse_json<let StringBytes: u32>(s: [u8; StringBytes]) -> Self {
             JSON { inner: crate::json::JSON::parse_json(s) }
         }
         fn get_length(self) -> u32 {
             self.inner.get_length()
         }
-        fn get_array<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<Self> {
+        fn get_array<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
             JSON::convert(self.inner.get_array(key))
         }
-        fn get_array_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Self {
+        fn get_array_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
             JSON { inner: self.inner.get_array_unchecked(key) }
         }
-        fn get_array_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+        fn get_array_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_array_var(key))
             }
         }
-        fn get_array_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
+        fn get_array_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
             JSON { inner: self.inner.get_array_unchecked_var(key) }
         }
         fn get_array_from_array(self, array_index: Field) -> Option<Self> {
@@ -769,20 +769,20 @@ mod JSON8kb {
         ) -> [U; MaxElements] where U: std::default::Default {
             self.inner.map(f)
         }
-        fn get_object<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<Self> {
+        fn get_object<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_object(key))
             }
         }
-        fn get_object_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Self {
+        fn get_object_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
             JSON { inner: self.inner.get_object_unchecked(key) }
         }
-        fn get_object_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+        fn get_object_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_object_var(key))
             }
         }
-        fn get_object_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
+        fn get_object_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
             JSON { inner: self.inner.get_object_unchecked_var(key) }
         }
         fn get_object_from_array(self, array_index: Field) -> Option<Self> {
@@ -791,16 +791,16 @@ mod JSON8kb {
         fn get_object_from_array_unchecked(self, array_index: Field) -> Self {
             JSON { inner: self.inner.get_object_from_array_unchecked(array_index) }
         }
-        fn get_literal<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<crate::JSONLiteral> {
+        fn get_literal<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<crate::JSONLiteral> {
             self.inner.get_literal(key)
         }
-        fn get_literal_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> crate::JSONLiteral {
+        fn get_literal_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> crate::JSONLiteral {
             self.inner.get_literal_unchecked(key)
         }
-        fn get_literal_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONLiteral> {
+        fn get_literal_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONLiteral> {
             self.inner.get_literal_var(key)
         }
-        fn get_literal_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONLiteral {
+        fn get_literal_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONLiteral {
             self.inner.get_literal_unchecked_var(key)
         }
         fn get_literal_from_array(self, array_index: Field) -> Option<crate::JSONLiteral> {
@@ -809,16 +809,16 @@ mod JSON8kb {
         fn get_literal_from_array_unchecked(self, array_index: Field) -> crate::JSONLiteral {
             self.inner.get_literal_from_array_unchecked(array_index)
         }
-        fn get_number<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<u64> {
+        fn get_number<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<u64> {
             self.inner.get_number(key)
         }
-        fn get_number_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> u64 {
+        fn get_number_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> u64 {
             self.inner.get_number_unchecked(key)
         }
-        fn get_number_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64> {
+        fn get_number_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64> {
             self.inner.get_number_var(key)
         }
-        fn get_number_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> u64 {
+        fn get_number_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> u64 {
             self.inner.get_number_unchecked_var(key)
         }
         fn get_number_from_array(self, array_index: Field) -> Option<u64> {
@@ -827,58 +827,58 @@ mod JSON8kb {
         fn get_number_from_array_unchecked(self, array_index: Field) -> u64 {
             self.inner.get_number_from_array_unchecked(array_index)
         }
-        fn get_string<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string(key)
         }
-        fn get_string_unchecked<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> BoundedVec<u8, StringBytes> {
+        fn get_string_unchecked<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_unchecked(key)
         }
-        fn get_string_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_var(key)
         }
-        fn get_string_unchecked_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> BoundedVec<u8, StringBytes> {
+        fn get_string_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_unchecked_var(key)
         }
-        fn get_string_from_array<let StringBytes: u16>(self, array_index: Field) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string_from_array<let StringBytes: u32>(self, array_index: Field) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_from_array(array_index)
         }
-        fn get_string_from_array_unchecked<let StringBytes: u16>(self, array_index: Field) -> BoundedVec<u8, StringBytes> {
+        fn get_string_from_array_unchecked<let StringBytes: u32>(self, array_index: Field) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_from_array_unchecked(array_index)
         }
-        fn get_string_from_path<let KeyBytes: u16, let StringBytes: u16, let PathDepth: u16>(
+        fn get_string_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
             self,
             keys: [BoundedVec<u8, KeyBytes>; PathDepth]
         ) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_from_path(keys)
         }
-        fn get_value<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value(key)
         }
-        fn get_value_unchecked<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> crate::JSONValue<StringBytes> {
+        fn get_value_unchecked<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_unchecked(key)
         }
-        fn get_value_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_var(key)
         }
-        fn get_value_unchecked_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONValue<StringBytes> {
+        fn get_value_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_unchecked_var(key)
         }
-        fn get_value_from_array<let StringBytes: u16>(self, array_index: Field) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value_from_array<let StringBytes: u32>(self, array_index: Field) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_from_array(array_index)
         }
-        fn get_value_from_array_unchecked<let StringBytes: u16>(self, array_index: Field) -> crate::JSONValue<StringBytes> {
+        fn get_value_from_array_unchecked<let StringBytes: u32>(self, array_index: Field) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_from_array_unchecked(array_index)
         }
-        fn get_value_from_path<let KeyBytes: u16, let StringBytes: u16, let PathDepth: u16>(
+        fn get_value_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
             self,
             keys: [BoundedVec<u8, KeyBytes>; PathDepth]
         ) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_from_path(keys)
         }
-        fn key_exists<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> bool {
+        fn key_exists<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> bool {
             self.inner.key_exists(key)
         }
-        fn get_keys_at_root<let MaxNumKeys: u16, let MaxKeyBytes: u16>(self) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
+        fn get_keys_at_root<let MaxNumKeys: u32, let MaxKeyBytes: u32>(self) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
             self.inner.get_keys_at_root()
         }
     }
@@ -895,28 +895,28 @@ mod JSON16kb {
         }
     }
     impl crate::JSONParserTrait for JSON {
-        fn parse_json_from_string<let StringBytes: u16>(s: str<StringBytes>) -> Self {
+        fn parse_json_from_string<let StringBytes: u32>(s: str<StringBytes>) -> Self {
             JSON { inner: crate::json::JSON::parse_json_from_string(s) }
         }
 
-        fn parse_json<let StringBytes: u16>(s: [u8; StringBytes]) -> Self {
+        fn parse_json<let StringBytes: u32>(s: [u8; StringBytes]) -> Self {
             JSON { inner: crate::json::JSON::parse_json(s) }
         }
         fn get_length(self) -> u32 {
             self.inner.get_length()
         }
-        fn get_array<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<Self> {
+        fn get_array<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
             JSON::convert(self.inner.get_array(key))
         }
-        fn get_array_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Self {
+        fn get_array_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
             JSON { inner: self.inner.get_array_unchecked(key) }
         }
-        fn get_array_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+        fn get_array_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_array_var(key))
             }
         }
-        fn get_array_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
+        fn get_array_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
             JSON { inner: self.inner.get_array_unchecked_var(key) }
         }
         fn get_array_from_array(self, array_index: Field) -> Option<Self> {
@@ -931,20 +931,20 @@ mod JSON16kb {
         ) -> [U; MaxElements] where U: std::default::Default {
             self.inner.map(f)
         }
-        fn get_object<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<Self> {
+        fn get_object<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_object(key))
             }
         }
-        fn get_object_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Self {
+        fn get_object_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
             JSON { inner: self.inner.get_object_unchecked(key) }
         }
-        fn get_object_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+        fn get_object_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
             {
                 JSON::convert(self.inner.get_object_var(key))
             }
         }
-        fn get_object_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
+        fn get_object_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
             JSON { inner: self.inner.get_object_unchecked_var(key) }
         }
         fn get_object_from_array(self, array_index: Field) -> Option<Self> {
@@ -953,16 +953,16 @@ mod JSON16kb {
         fn get_object_from_array_unchecked(self, array_index: Field) -> Self {
             JSON { inner: self.inner.get_object_from_array_unchecked(array_index) }
         }
-        fn get_literal<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<crate::JSONLiteral> {
+        fn get_literal<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<crate::JSONLiteral> {
             self.inner.get_literal(key)
         }
-        fn get_literal_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> crate::JSONLiteral {
+        fn get_literal_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> crate::JSONLiteral {
             self.inner.get_literal_unchecked(key)
         }
-        fn get_literal_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONLiteral> {
+        fn get_literal_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONLiteral> {
             self.inner.get_literal_var(key)
         }
-        fn get_literal_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONLiteral {
+        fn get_literal_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONLiteral {
             self.inner.get_literal_unchecked_var(key)
         }
         fn get_literal_from_array(self, array_index: Field) -> Option<crate::JSONLiteral> {
@@ -971,16 +971,16 @@ mod JSON16kb {
         fn get_literal_from_array_unchecked(self, array_index: Field) -> crate::JSONLiteral {
             self.inner.get_literal_from_array_unchecked(array_index)
         }
-        fn get_number<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> Option<u64> {
+        fn get_number<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<u64> {
             self.inner.get_number(key)
         }
-        fn get_number_unchecked<let KeyBytes: u16>(self, key: [u8; KeyBytes]) -> u64 {
+        fn get_number_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> u64 {
             self.inner.get_number_unchecked(key)
         }
-        fn get_number_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64> {
+        fn get_number_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64> {
             self.inner.get_number_var(key)
         }
-        fn get_number_unchecked_var<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> u64 {
+        fn get_number_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> u64 {
             self.inner.get_number_unchecked_var(key)
         }
         fn get_number_from_array(self, array_index: Field) -> Option<u64> {
@@ -989,58 +989,58 @@ mod JSON16kb {
         fn get_number_from_array_unchecked(self, array_index: Field) -> u64 {
             self.inner.get_number_from_array_unchecked(array_index)
         }
-        fn get_string<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string(key)
         }
-        fn get_string_unchecked<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> BoundedVec<u8, StringBytes> {
+        fn get_string_unchecked<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_unchecked(key)
         }
-        fn get_string_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_var(key)
         }
-        fn get_string_unchecked_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> BoundedVec<u8, StringBytes> {
+        fn get_string_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_unchecked_var(key)
         }
-        fn get_string_from_array<let StringBytes: u16>(self, array_index: Field) -> Option<BoundedVec<u8, StringBytes>> {
+        fn get_string_from_array<let StringBytes: u32>(self, array_index: Field) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_from_array(array_index)
         }
-        fn get_string_from_array_unchecked<let StringBytes: u16>(self, array_index: Field) -> BoundedVec<u8, StringBytes> {
+        fn get_string_from_array_unchecked<let StringBytes: u32>(self, array_index: Field) -> BoundedVec<u8, StringBytes> {
             self.inner.get_string_from_array_unchecked(array_index)
         }
-        fn get_string_from_path<let KeyBytes: u16, let StringBytes: u16, let PathDepth: u16>(
+        fn get_string_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
             self,
             keys: [BoundedVec<u8, KeyBytes>; PathDepth]
         ) -> Option<BoundedVec<u8, StringBytes>> {
             self.inner.get_string_from_path(keys)
         }
-        fn get_value<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value(key)
         }
-        fn get_value_unchecked<let KeyBytes: u16, let StringBytes: u16>(self, key: [u8; KeyBytes]) -> crate::JSONValue<StringBytes> {
+        fn get_value_unchecked<let KeyBytes: u32, let StringBytes: u32>(self, key: [u8; KeyBytes]) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_unchecked(key)
         }
-        fn get_value_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_var(key)
         }
-        fn get_value_unchecked_var<let KeyBytes: u16, let StringBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONValue<StringBytes> {
+        fn get_value_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_unchecked_var(key)
         }
-        fn get_value_from_array<let StringBytes: u16>(self, array_index: Field) -> Option<crate::JSONValue<StringBytes>> {
+        fn get_value_from_array<let StringBytes: u32>(self, array_index: Field) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_from_array(array_index)
         }
-        fn get_value_from_array_unchecked<let StringBytes: u16>(self, array_index: Field) -> crate::JSONValue<StringBytes> {
+        fn get_value_from_array_unchecked<let StringBytes: u32>(self, array_index: Field) -> crate::JSONValue<StringBytes> {
             self.inner.get_value_from_array_unchecked(array_index)
         }
-        fn get_value_from_path<let KeyBytes: u16, let StringBytes: u16, let PathDepth: u16>(
+        fn get_value_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
             self,
             keys: [BoundedVec<u8, KeyBytes>; PathDepth]
         ) -> Option<crate::JSONValue<StringBytes>> {
             self.inner.get_value_from_path(keys)
         }
-        fn key_exists<let KeyBytes: u16>(self, key: BoundedVec<u8, KeyBytes>) -> bool {
+        fn key_exists<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> bool {
             self.inner.key_exists(key)
         }
-        fn get_keys_at_root<let MaxNumKeys: u16, let MaxKeyBytes: u16>(self) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
+        fn get_keys_at_root<let MaxNumKeys: u32, let MaxKeyBytes: u32>(self) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
             self.inner.get_keys_at_root()
         }
     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR replaces the usage of u16s in the numeric generics with u32s in order to match the expected types of array lengths.

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
