### PR TITLE
feat!: support smaller jsonblobs

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,4 +5,4 @@ authors = [""]
 compiler_version = ">=0.37.0"
 
 [dependencies]
-noir_sort = {tag = "v0.2.0", git = "https://github.com/noir-lang/noir_sort"}
+noir_sort = {tag = "v0.2.1", git = "https://github.com/noir-lang/noir_sort"}

--- a/src/lib.nr
+++ b/src/lib.nr
@@ -125,6 +125,440 @@ trait JSONParserTrait {
     ) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys>;
 }
 
+mod JSON128b {
+    struct JSON {
+        inner: crate::json::JSON<128, 8, 16, 9, 2>,
+    }
+
+    impl JSON {
+        fn convert(inner: Option<crate::json::JSON<128, 8, 16, 9, 2>>) -> Option<Self> {
+            Option { _is_some: inner._is_some, _value: JSON { inner: inner._value } }
+        }
+    }
+    impl crate::JSONParserTrait for JSON {
+        fn parse_json_from_string<let StringBytes: u32>(s: str<StringBytes>) -> Self {
+            JSON { inner: crate::json::JSON::parse_json_from_string(s) }
+        }
+
+        fn parse_json<let StringBytes: u32>(s: [u8; StringBytes]) -> Self {
+            JSON { inner: crate::json::JSON::parse_json(s) }
+        }
+        fn get_length(self) -> u32 {
+            self.inner.get_length()
+        }
+        fn get_array<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
+            JSON::convert(self.inner.get_array(key))
+        }
+        fn get_array_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
+            JSON { inner: self.inner.get_array_unchecked(key) }
+        }
+        fn get_array_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+            {
+                JSON::convert(self.inner.get_array_var(key))
+            }
+        }
+        fn get_array_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
+            JSON { inner: self.inner.get_array_unchecked_var(key) }
+        }
+        fn get_array_from_array(self, array_index: Field) -> Option<Self> {
+            JSON::convert(self.inner.get_array_from_array(array_index))
+        }
+        fn get_array_from_array_unchecked(self, array_index: Field) -> Self {
+            JSON { inner: self.inner.get_array_from_array_unchecked(array_index) }
+        }
+        fn map<U, let MaxElements: u32, let MaxElementBytes: u32>(
+            self,
+            f: fn(crate::JSONValue<MaxElementBytes>) -> U,
+        ) -> [U; MaxElements]
+        where
+            U: std::default::Default,
+        {
+            self.inner.map(f)
+        }
+        fn get_object<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
+            {
+                JSON::convert(self.inner.get_object(key))
+            }
+        }
+        fn get_object_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
+            JSON { inner: self.inner.get_object_unchecked(key) }
+        }
+        fn get_object_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+            {
+                JSON::convert(self.inner.get_object_var(key))
+            }
+        }
+        fn get_object_unchecked_var<let KeyBytes: u32>(
+            self,
+            key: BoundedVec<u8, KeyBytes>,
+        ) -> Self {
+            JSON { inner: self.inner.get_object_unchecked_var(key) }
+        }
+        fn get_object_from_array(self, array_index: Field) -> Option<Self> {
+            JSON::convert(self.inner.get_object_from_array(array_index))
+        }
+        fn get_object_from_array_unchecked(self, array_index: Field) -> Self {
+            JSON { inner: self.inner.get_object_from_array_unchecked(array_index) }
+        }
+        fn get_literal<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<crate::JSONLiteral> {
+            self.inner.get_literal(key)
+        }
+        fn get_literal_unchecked<let KeyBytes: u32>(
+            self,
+            key: [u8; KeyBytes],
+        ) -> crate::JSONLiteral {
+            self.inner.get_literal_unchecked(key)
+        }
+        fn get_literal_var<let KeyBytes: u32>(
+            self,
+            key: BoundedVec<u8, KeyBytes>,
+        ) -> Option<crate::JSONLiteral> {
+            self.inner.get_literal_var(key)
+        }
+        fn get_literal_unchecked_var<let KeyBytes: u32>(
+            self,
+            key: BoundedVec<u8, KeyBytes>,
+        ) -> crate::JSONLiteral {
+            self.inner.get_literal_unchecked_var(key)
+        }
+        fn get_literal_from_array(self, array_index: Field) -> Option<crate::JSONLiteral> {
+            self.inner.get_literal_from_array(array_index)
+        }
+        fn get_literal_from_array_unchecked(self, array_index: Field) -> crate::JSONLiteral {
+            self.inner.get_literal_from_array_unchecked(array_index)
+        }
+        fn get_number<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<u64> {
+            self.inner.get_number(key)
+        }
+        fn get_number_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> u64 {
+            self.inner.get_number_unchecked(key)
+        }
+        fn get_number_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64> {
+            self.inner.get_number_var(key)
+        }
+        fn get_number_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> u64 {
+            self.inner.get_number_unchecked_var(key)
+        }
+        fn get_number_from_array(self, array_index: Field) -> Option<u64> {
+            self.inner.get_number_from_array(array_index)
+        }
+        fn get_number_from_array_unchecked(self, array_index: Field) -> u64 {
+            self.inner.get_number_from_array_unchecked(array_index)
+        }
+
+        fn get_string<let KeyBytes: u32, let StringBytes: u32>(
+            self,
+            key: [u8; KeyBytes],
+        ) -> Option<BoundedVec<u8, StringBytes>> {
+            self.inner.get_string(key)
+        }
+        fn get_string_unchecked<let KeyBytes: u32, let StringBytes: u32>(
+            self,
+            key: [u8; KeyBytes],
+        ) -> BoundedVec<u8, StringBytes> {
+            self.inner.get_string_unchecked(key)
+        }
+        fn get_string_var<let KeyBytes: u32, let StringBytes: u32>(
+            self,
+            key: BoundedVec<u8, KeyBytes>,
+        ) -> Option<BoundedVec<u8, StringBytes>> {
+            self.inner.get_string_var(key)
+        }
+        fn get_string_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(
+            self,
+            key: BoundedVec<u8, KeyBytes>,
+        ) -> BoundedVec<u8, StringBytes> {
+            self.inner.get_string_unchecked_var(key)
+        }
+        fn get_string_from_array<let StringBytes: u32>(
+            self,
+            array_index: Field,
+        ) -> Option<BoundedVec<u8, StringBytes>> {
+            self.inner.get_string_from_array(array_index)
+        }
+        fn get_string_from_array_unchecked<let StringBytes: u32>(
+            self,
+            array_index: Field,
+        ) -> BoundedVec<u8, StringBytes> {
+            self.inner.get_string_from_array_unchecked(array_index)
+        }
+        fn get_string_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
+            self,
+            keys: [BoundedVec<u8, KeyBytes>; PathDepth],
+        ) -> Option<BoundedVec<u8, StringBytes>> {
+            self.inner.get_string_from_path(keys)
+        }
+        fn get_value<let KeyBytes: u32, let StringBytes: u32>(
+            self,
+            key: [u8; KeyBytes],
+        ) -> Option<crate::JSONValue<StringBytes>> {
+            self.inner.get_value(key)
+        }
+        fn get_value_unchecked<let KeyBytes: u32, let StringBytes: u32>(
+            self,
+            key: [u8; KeyBytes],
+        ) -> crate::JSONValue<StringBytes> {
+            self.inner.get_value_unchecked(key)
+        }
+        fn get_value_var<let KeyBytes: u32, let StringBytes: u32>(
+            self,
+            key: BoundedVec<u8, KeyBytes>,
+        ) -> Option<crate::JSONValue<StringBytes>> {
+            self.inner.get_value_var(key)
+        }
+        fn get_value_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(
+            self,
+            key: BoundedVec<u8, KeyBytes>,
+        ) -> crate::JSONValue<StringBytes> {
+            self.inner.get_value_unchecked_var(key)
+        }
+        fn get_value_from_array<let StringBytes: u32>(
+            self,
+            array_index: Field,
+        ) -> Option<crate::JSONValue<StringBytes>> {
+            self.inner.get_value_from_array(array_index)
+        }
+        fn get_value_from_array_unchecked<let StringBytes: u32>(
+            self,
+            array_index: Field,
+        ) -> crate::JSONValue<StringBytes> {
+            self.inner.get_value_from_array_unchecked(array_index)
+        }
+        fn get_value_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
+            self,
+            keys: [BoundedVec<u8, KeyBytes>; PathDepth],
+        ) -> Option<crate::JSONValue<StringBytes>> {
+            self.inner.get_value_from_path(keys)
+        }
+
+        fn key_exists<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> bool {
+            self.inner.key_exists(key)
+        }
+        fn get_keys_at_root<let MaxNumKeys: u32, let MaxKeyBytes: u32>(
+            self,
+        ) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
+            self.inner.get_keys_at_root()
+        }
+    }
+}
+
+mod JSON256b {
+    struct JSON {
+        inner: crate::json::JSON<256, 12, 32, 17, 2>,
+    }
+
+    impl JSON {
+        fn convert(inner: Option<crate::json::JSON<256, 12, 32, 17, 2>>) -> Option<Self> {
+            Option { _is_some: inner._is_some, _value: JSON { inner: inner._value } }
+        }
+    }
+    impl crate::JSONParserTrait for JSON {
+        fn parse_json_from_string<let StringBytes: u32>(s: str<StringBytes>) -> Self {
+            JSON { inner: crate::json::JSON::parse_json_from_string(s) }
+        }
+
+        fn parse_json<let StringBytes: u32>(s: [u8; StringBytes]) -> Self {
+            JSON { inner: crate::json::JSON::parse_json(s) }
+        }
+        fn get_length(self) -> u32 {
+            self.inner.get_length()
+        }
+        fn get_array<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
+            JSON::convert(self.inner.get_array(key))
+        }
+        fn get_array_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
+            JSON { inner: self.inner.get_array_unchecked(key) }
+        }
+        fn get_array_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+            {
+                JSON::convert(self.inner.get_array_var(key))
+            }
+        }
+        fn get_array_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Self {
+            JSON { inner: self.inner.get_array_unchecked_var(key) }
+        }
+        fn get_array_from_array(self, array_index: Field) -> Option<Self> {
+            JSON::convert(self.inner.get_array_from_array(array_index))
+        }
+        fn get_array_from_array_unchecked(self, array_index: Field) -> Self {
+            JSON { inner: self.inner.get_array_from_array_unchecked(array_index) }
+        }
+        fn map<U, let MaxElements: u32, let MaxElementBytes: u32>(
+            self,
+            f: fn(crate::JSONValue<MaxElementBytes>) -> U,
+        ) -> [U; MaxElements]
+        where
+            U: std::default::Default,
+        {
+            self.inner.map(f)
+        }
+        fn get_object<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<Self> {
+            {
+                JSON::convert(self.inner.get_object(key))
+            }
+        }
+        fn get_object_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
+            JSON { inner: self.inner.get_object_unchecked(key) }
+        }
+        fn get_object_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<Self> {
+            {
+                JSON::convert(self.inner.get_object_var(key))
+            }
+        }
+        fn get_object_unchecked_var<let KeyBytes: u32>(
+            self,
+            key: BoundedVec<u8, KeyBytes>,
+        ) -> Self {
+            JSON { inner: self.inner.get_object_unchecked_var(key) }
+        }
+        fn get_object_from_array(self, array_index: Field) -> Option<Self> {
+            JSON::convert(self.inner.get_object_from_array(array_index))
+        }
+        fn get_object_from_array_unchecked(self, array_index: Field) -> Self {
+            JSON { inner: self.inner.get_object_from_array_unchecked(array_index) }
+        }
+        fn get_literal<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<crate::JSONLiteral> {
+            self.inner.get_literal(key)
+        }
+        fn get_literal_unchecked<let KeyBytes: u32>(
+            self,
+            key: [u8; KeyBytes],
+        ) -> crate::JSONLiteral {
+            self.inner.get_literal_unchecked(key)
+        }
+        fn get_literal_var<let KeyBytes: u32>(
+            self,
+            key: BoundedVec<u8, KeyBytes>,
+        ) -> Option<crate::JSONLiteral> {
+            self.inner.get_literal_var(key)
+        }
+        fn get_literal_unchecked_var<let KeyBytes: u32>(
+            self,
+            key: BoundedVec<u8, KeyBytes>,
+        ) -> crate::JSONLiteral {
+            self.inner.get_literal_unchecked_var(key)
+        }
+        fn get_literal_from_array(self, array_index: Field) -> Option<crate::JSONLiteral> {
+            self.inner.get_literal_from_array(array_index)
+        }
+        fn get_literal_from_array_unchecked(self, array_index: Field) -> crate::JSONLiteral {
+            self.inner.get_literal_from_array_unchecked(array_index)
+        }
+        fn get_number<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Option<u64> {
+            self.inner.get_number(key)
+        }
+        fn get_number_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> u64 {
+            self.inner.get_number_unchecked(key)
+        }
+        fn get_number_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> Option<u64> {
+            self.inner.get_number_var(key)
+        }
+        fn get_number_unchecked_var<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> u64 {
+            self.inner.get_number_unchecked_var(key)
+        }
+        fn get_number_from_array(self, array_index: Field) -> Option<u64> {
+            self.inner.get_number_from_array(array_index)
+        }
+        fn get_number_from_array_unchecked(self, array_index: Field) -> u64 {
+            self.inner.get_number_from_array_unchecked(array_index)
+        }
+
+        fn get_string<let KeyBytes: u32, let StringBytes: u32>(
+            self,
+            key: [u8; KeyBytes],
+        ) -> Option<BoundedVec<u8, StringBytes>> {
+            self.inner.get_string(key)
+        }
+        fn get_string_unchecked<let KeyBytes: u32, let StringBytes: u32>(
+            self,
+            key: [u8; KeyBytes],
+        ) -> BoundedVec<u8, StringBytes> {
+            self.inner.get_string_unchecked(key)
+        }
+        fn get_string_var<let KeyBytes: u32, let StringBytes: u32>(
+            self,
+            key: BoundedVec<u8, KeyBytes>,
+        ) -> Option<BoundedVec<u8, StringBytes>> {
+            self.inner.get_string_var(key)
+        }
+        fn get_string_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(
+            self,
+            key: BoundedVec<u8, KeyBytes>,
+        ) -> BoundedVec<u8, StringBytes> {
+            self.inner.get_string_unchecked_var(key)
+        }
+        fn get_string_from_array<let StringBytes: u32>(
+            self,
+            array_index: Field,
+        ) -> Option<BoundedVec<u8, StringBytes>> {
+            self.inner.get_string_from_array(array_index)
+        }
+        fn get_string_from_array_unchecked<let StringBytes: u32>(
+            self,
+            array_index: Field,
+        ) -> BoundedVec<u8, StringBytes> {
+            self.inner.get_string_from_array_unchecked(array_index)
+        }
+        fn get_string_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
+            self,
+            keys: [BoundedVec<u8, KeyBytes>; PathDepth],
+        ) -> Option<BoundedVec<u8, StringBytes>> {
+            self.inner.get_string_from_path(keys)
+        }
+        fn get_value<let KeyBytes: u32, let StringBytes: u32>(
+            self,
+            key: [u8; KeyBytes],
+        ) -> Option<crate::JSONValue<StringBytes>> {
+            self.inner.get_value(key)
+        }
+        fn get_value_unchecked<let KeyBytes: u32, let StringBytes: u32>(
+            self,
+            key: [u8; KeyBytes],
+        ) -> crate::JSONValue<StringBytes> {
+            self.inner.get_value_unchecked(key)
+        }
+        fn get_value_var<let KeyBytes: u32, let StringBytes: u32>(
+            self,
+            key: BoundedVec<u8, KeyBytes>,
+        ) -> Option<crate::JSONValue<StringBytes>> {
+            self.inner.get_value_var(key)
+        }
+        fn get_value_unchecked_var<let KeyBytes: u32, let StringBytes: u32>(
+            self,
+            key: BoundedVec<u8, KeyBytes>,
+        ) -> crate::JSONValue<StringBytes> {
+            self.inner.get_value_unchecked_var(key)
+        }
+        fn get_value_from_array<let StringBytes: u32>(
+            self,
+            array_index: Field,
+        ) -> Option<crate::JSONValue<StringBytes>> {
+            self.inner.get_value_from_array(array_index)
+        }
+        fn get_value_from_array_unchecked<let StringBytes: u32>(
+            self,
+            array_index: Field,
+        ) -> crate::JSONValue<StringBytes> {
+            self.inner.get_value_from_array_unchecked(array_index)
+        }
+        fn get_value_from_path<let KeyBytes: u32, let StringBytes: u32, let PathDepth: u32>(
+            self,
+            keys: [BoundedVec<u8, KeyBytes>; PathDepth],
+        ) -> Option<crate::JSONValue<StringBytes>> {
+            self.inner.get_value_from_path(keys)
+        }
+
+        fn key_exists<let KeyBytes: u32>(self, key: BoundedVec<u8, KeyBytes>) -> bool {
+            self.inner.key_exists(key)
+        }
+        fn get_keys_at_root<let MaxNumKeys: u32, let MaxKeyBytes: u32>(
+            self,
+        ) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
+            self.inner.get_keys_at_root()
+        }
+    }
+}
+
 mod JSON512b {
     struct JSON {
         inner: crate::json::JSON<512, 20, 64, 33, 2>,


### PR DESCRIPTION
# Description

Adds support for 128 byte and 256 byte json blobs

## Problem\*

When fuzzing this library, having smaller json objects helps speed up tests

## Summary\*

JSON128b and JSON256b are new classes in `lib.nr`

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
