### PR TITLE
chore: replace `root_index_in_transcript` with `u32`

### DIFF
--- a/src/get_array.nr
+++ b/src/get_array.nr
@@ -135,7 +135,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let entry_index = (parent_entry.child_pointer + array_index) * valid as Field;
 
         let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(entry_index)].into();
-        if !valid {
+        if valid {
             assert_eq(
                 entry.entry_type,
                 END_ARRAY_TOKEN as Field,

--- a/src/get_array.nr
+++ b/src/get_array.nr
@@ -17,7 +17,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
     pub(crate) fn get_length(self) -> u32 {
         assert(self.layer_type_of_root == ARRAY_LAYER, "can only get length of an array type");
         let parent_entry: JSONEntry =
-            self.json_entries_packed[cast_num_to_u32(self.root_index_in_transcript)].into();
+            self.json_entries_packed[self.root_index_in_transcript].into();
         parent_entry.num_children as u32
     }
 
@@ -38,7 +38,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         r.layer_type_of_root = cast_num_to_u32(entry.parent_index);
         r.root_id = entry.id;
         r.layer_type_of_root = ARRAY_LAYER;
-        r.root_index_in_transcript = key_index as Field;
+        r.root_index_in_transcript = key_index;
 
         if exists {
             Option::some(r)
@@ -77,16 +77,19 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let (exists, key_index) = self.key_exists_impl_var(key);
         let entry: JSONEntry = self.json_entries_packed[key_index].into();
         // TODO: ADD A layer_context VARIABLE INTO JSON WHICH DESCRIBES WHETHER WE ARE AN OBJECT, ARRAY OR SINGLE VALUE
-        assert(
-            (entry.entry_type - END_ARRAY_TOKEN as Field) * exists as Field == 0,
-            "key does not describe an object",
-        );
+        if !exists {
+            assert_eq(
+                entry.entry_type,
+                END_ARRAY_TOKEN as Field,
+                "key does not describe an object",
+            );
+        }
 
         let mut r = self;
         r.layer_type_of_root = cast_num_to_u32(entry.parent_index);
         r.root_id = entry.id;
         r.layer_type_of_root = ARRAY_LAYER;
-        r.root_index_in_transcript = key_index as Field;
+        r.root_index_in_transcript = key_index;
 
         if exists {
             Option::some(r)
@@ -127,21 +130,24 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         );
 
         let parent_entry: JSONEntry =
-            self.json_entries_packed[cast_num_to_u32(self.root_index_in_transcript)].into();
+            self.json_entries_packed[self.root_index_in_transcript].into();
         let valid = lt_field_16_bit(array_index, parent_entry.num_children);
         let entry_index = (parent_entry.child_pointer + array_index) * valid as Field;
 
         let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(entry_index)].into();
-        assert(
-            (entry.entry_type - END_ARRAY_TOKEN as Field) * valid as Field == 0,
-            "get_object_from_array: entry exists but is not an object!",
-        );
+        if !valid {
+            assert_eq(
+                entry.entry_type,
+                END_ARRAY_TOKEN as Field,
+                "get_object_from_array: entry exists but is not an object!",
+            );
+        }
 
         let mut r = self;
         r.layer_type_of_root = cast_num_to_u32(entry.parent_index);
         r.root_id = entry.id;
         r.layer_type_of_root = ARRAY_LAYER;
-        r.root_index_in_transcript = entry_index;
+        r.root_index_in_transcript = cast_num_to_u32(entry_index);
 
         if valid {
             Option::some(r)
@@ -161,7 +167,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         );
 
         let parent_entry: JSONEntry =
-            self.json_entries_packed[cast_num_to_u32(self.root_index_in_transcript)].into();
+            self.json_entries_packed[self.root_index_in_transcript].into();
         let valid = lt_field_16_bit(array_index, parent_entry.num_children);
         assert(valid, "array overflow");
         let entry_index = (parent_entry.child_pointer + array_index);
@@ -175,7 +181,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         r.layer_type_of_root = cast_num_to_u32(entry.parent_index);
         r.root_id = entry.id;
         r.layer_type_of_root = ARRAY_LAYER;
-        r.root_index_in_transcript = entry_index;
+        r.root_index_in_transcript = cast_num_to_u32(entry_index);
         r
     }
 
@@ -191,8 +197,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
     {
         assert(self.layer_type_of_root == ARRAY_LAYER, "can only call map on an array");
 
-        let entry: JSONEntry =
-            self.json_entries_packed[cast_num_to_u32(self.root_index_in_transcript)].into();
+        let entry: JSONEntry = self.json_entries_packed[self.root_index_in_transcript].into();
         let num_children = entry.num_children;
         let mut r: [U; MaxElements] = [U::default(); MaxElements];
 

--- a/src/get_literal.nr
+++ b/src/get_literal.nr
@@ -170,7 +170,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let entry_index = (parent_entry.child_pointer + array_index) * valid as Field;
 
         let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(entry_index)].into();
-        if !valid {
+        if valid {
             assert_eq(
                 entry.entry_type,
                 LITERAL_TOKEN as Field,

--- a/src/get_literal.nr
+++ b/src/get_literal.nr
@@ -164,17 +164,19 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         );
 
         let parent_entry: JSONEntry =
-            self.json_entries_packed[cast_num_to_u32(self.root_index_in_transcript)].into();
+            self.json_entries_packed[self.root_index_in_transcript].into();
 
         let valid = lt_field_16_bit(array_index, parent_entry.num_children);
         let entry_index = (parent_entry.child_pointer + array_index) * valid as Field;
 
         let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(entry_index)].into();
-
-        assert(
-            (entry.entry_type - LITERAL_TOKEN as Field) * valid as Field == 0,
-            "get_literal_from_array: entry exists but is not a literal!",
-        );
+        if !valid {
+            assert_eq(
+                entry.entry_type,
+                LITERAL_TOKEN as Field,
+                "get_literal_from_array: entry exists but is not a literal!",
+            );
+        }
 
         let mut parsed_string: [u8; MAX_LITERAL_LENGTH_AS_STRING] =
             self.extract_string_entry(entry);
@@ -198,7 +200,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         );
 
         let parent_entry: JSONEntry =
-            self.json_entries_packed[cast_num_to_u32(self.root_index_in_transcript)].into();
+            self.json_entries_packed[self.root_index_in_transcript].into();
 
         let valid = lt_field_16_bit(array_index, parent_entry.num_children);
         assert(valid, "array overflow");

--- a/src/get_number.nr
+++ b/src/get_number.nr
@@ -133,7 +133,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let entry_index = (parent_entry.child_pointer + array_index) * valid as Field;
 
         let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(entry_index)].into();
-        if !valid {
+        if valid {
             assert_eq(
                 entry.entry_type,
                 NUMERIC_TOKEN as Field,

--- a/src/get_number.nr
+++ b/src/get_number.nr
@@ -127,17 +127,19 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         );
 
         let parent_entry: JSONEntry =
-            self.json_entries_packed[cast_num_to_u32(self.root_index_in_transcript)].into();
+            self.json_entries_packed[self.root_index_in_transcript].into();
 
         let valid = lt_field_16_bit(array_index, parent_entry.num_children);
         let entry_index = (parent_entry.child_pointer + array_index) * valid as Field;
 
         let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(entry_index)].into();
-
-        assert(
-            (entry.entry_type - NUMERIC_TOKEN as Field) * valid as Field == 0,
-            "get_number: entry exists but is not a number!",
-        );
+        if !valid {
+            assert_eq(
+                entry.entry_type,
+                NUMERIC_TOKEN as Field,
+                "get_number: entry exists but is not a number!",
+            );
+        }
 
         let mut parsed_string: [u8; U64_LENGTH_AS_BASE10_STRING] = self.extract_string_entry(entry);
         let result = extract_number_from_array(parsed_string, entry.json_length);
@@ -160,7 +162,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         );
 
         let parent_entry: JSONEntry =
-            self.json_entries_packed[cast_num_to_u32(self.root_index_in_transcript)].into();
+            self.json_entries_packed[self.root_index_in_transcript].into();
 
         let valid = lt_field_16_bit(array_index, parent_entry.num_children);
         assert(valid, "array overflow");

--- a/src/get_object.nr
+++ b/src/get_object.nr
@@ -125,7 +125,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let entry_index = (parent_entry.child_pointer + array_index) * valid as Field;
 
         let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(entry_index)].into();
-        if !valid {
+        if valid {
             assert_eq(
                 entry.entry_type,
                 END_OBJECT_TOKEN as Field,

--- a/src/get_object.nr
+++ b/src/get_object.nr
@@ -28,7 +28,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         r.layer_type_of_root = cast_num_to_u32(entry.parent_index);
         r.root_id = entry.id;
         r.layer_type_of_root = OBJECT_LAYER;
-        r.root_index_in_transcript = key_index as Field;
+        r.root_index_in_transcript = key_index;
         if exists {
             Option::some(r)
         } else {
@@ -43,7 +43,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
     pub(crate) fn get_object_unchecked<let KeyBytes: u32>(self, key: [u8; KeyBytes]) -> Self {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
         let (entry, key_index) = self.get_json_entry_unchecked_with_key_index(key);
-        let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(key_index)].into();
+        let entry: JSONEntry = self.json_entries_packed[key_index].into();
         assert(
             entry.entry_type == END_OBJECT_TOKEN as Field,
             "get_object: entry exists but is not an object!",
@@ -77,7 +77,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         r.layer_type_of_root = cast_num_to_u32(entry.parent_index);
         r.root_id = entry.id;
         r.layer_type_of_root = OBJECT_LAYER;
-        r.root_index_in_transcript = key_index as Field;
+        r.root_index_in_transcript = key_index;
         if exists {
             Option::some(r)
         } else {
@@ -94,7 +94,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
     ) -> Self {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
         let (entry, key_index) = self.get_json_entry_unchecked_with_key_index_var(key);
-        let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(key_index)].into();
+        let entry: JSONEntry = self.json_entries_packed[key_index].into();
         assert(
             entry.entry_type == END_OBJECT_TOKEN as Field,
             "get_object: entry exists but is not an object!",
@@ -119,23 +119,25 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         );
 
         let parent_entry: JSONEntry =
-            self.json_entries_packed[cast_num_to_u32(self.root_index_in_transcript)].into();
+            self.json_entries_packed[self.root_index_in_transcript].into();
 
         let valid = lt_field_16_bit(array_index, parent_entry.num_children);
         let entry_index = (parent_entry.child_pointer + array_index) * valid as Field;
 
         let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(entry_index)].into();
-
-        assert(
-            (entry.entry_type - END_OBJECT_TOKEN as Field) * valid as Field == 0,
-            "get_object_from_array: entry exists but is not an object!",
-        );
+        if !valid {
+            assert_eq(
+                entry.entry_type,
+                END_OBJECT_TOKEN as Field,
+                "get_object_from_array: entry exists but is not an object!",
+            );
+        }
 
         let mut r = self;
         r.layer_type_of_root = cast_num_to_u32(entry.parent_index);
         r.root_id = entry.id;
         r.layer_type_of_root = OBJECT_LAYER;
-        r.root_index_in_transcript = entry_index;
+        r.root_index_in_transcript = cast_num_to_u32(entry_index);
 
         if valid {
             Option::some(r)
@@ -155,7 +157,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         );
 
         let parent_entry: JSONEntry =
-            self.json_entries_packed[cast_num_to_u32(self.root_index_in_transcript)].into();
+            self.json_entries_packed[self.root_index_in_transcript].into();
 
         let valid = lt_field_16_bit(array_index, parent_entry.num_children);
         assert(valid, "array overflow");
@@ -171,7 +173,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         r.layer_type_of_root = cast_num_to_u32(entry.parent_index);
         r.root_id = entry.id;
         r.layer_type_of_root = OBJECT_LAYER;
-        r.root_index_in_transcript = entry_index;
+        r.root_index_in_transcript = cast_num_to_u32(entry_index);
         r
     }
 }
@@ -193,13 +195,7 @@ fn test_object() {
     assert(B == B_alt.unwrap());
 
     let C = B.get_object_unchecked("bartholomew tony Harrison III".as_bytes());
-    assert(
-        JSONEntry::from(
-            C.json_entries_packed[cast_num_to_u32(C.root_index_in_transcript)],
-        )
-            .num_children
-            == 1,
-    );
+    assert_eq(JSONEntry::from(C.json_entries_packed[C.root_index_in_transcript]).num_children, 1);
 
     let not_real = B.get_object("bartholomew tony Harrison IV".as_bytes());
     assert(not_real.is_some() == false);
@@ -208,13 +204,7 @@ fn test_object() {
         "bartholomew tony Harrison III".as_bytes(),
         29,
     ));
-    assert(
-        JSONEntry::from(
-            C.json_entries_packed[cast_num_to_u32(C.root_index_in_transcript)],
-        )
-            .num_children
-            == 1,
-    );
+    assert_eq(JSONEntry::from(C.json_entries_packed[C.root_index_in_transcript]).num_children, 1);
 
     let C = B.get_object_var(BoundedVec::from_parts_unchecked(
         "bartholomew tony Harrison III".as_bytes(),

--- a/src/get_string.nr
+++ b/src/get_string.nr
@@ -207,7 +207,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let entry_index = (parent_entry.child_pointer + array_index) * valid as Field;
 
         let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(entry_index)].into();
-        if !valid {
+        if valid {
             assert_eq(
                 entry.entry_type,
                 STRING_TOKEN as Field,
@@ -387,7 +387,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let entry_index = (parent_entry.child_pointer + array_index) * valid as Field;
 
         let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(entry_index)].into();
-        if !valid {
+        if valid {
             assert_eq(
                 entry.entry_type,
                 STRING_TOKEN as Field,

--- a/src/get_string.nr
+++ b/src/get_string.nr
@@ -201,17 +201,19 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         );
 
         let parent_entry: JSONEntry =
-            self.json_entries_packed[cast_num_to_u32(self.root_index_in_transcript)].into();
+            self.json_entries_packed[self.root_index_in_transcript].into();
 
         let valid = lt_field_16_bit(array_index, parent_entry.num_children);
         let entry_index = (parent_entry.child_pointer + array_index) * valid as Field;
 
         let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(entry_index)].into();
-
-        assert(
-            (entry.entry_type - STRING_TOKEN as Field) * valid as Field == 0,
-            "get_array_element_as_string: entry exists but is not a string!",
-        );
+        if !valid {
+            assert_eq(
+                entry.entry_type,
+                STRING_TOKEN as Field,
+                "get_array_element_as_string: entry exists but is not a string!",
+            );
+        }
 
         let mut parsed_string: [u8; StringBytes] = self.extract_string_entry(entry);
         let parsed_string: BoundedVec<u8, StringBytes> = process_escape_sequences(
@@ -239,7 +241,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         );
 
         let parent_entry: JSONEntry =
-            self.json_entries_packed[cast_num_to_u32(self.root_index_in_transcript)].into();
+            self.json_entries_packed[self.root_index_in_transcript].into();
 
         let valid = lt_field_16_bit(array_index, parent_entry.num_children);
         assert(valid, "array overflow");
@@ -379,17 +381,19 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         );
 
         let parent_entry: JSONEntry =
-            self.json_entries_packed[cast_num_to_u32(self.root_index_in_transcript)].into();
+            self.json_entries_packed[self.root_index_in_transcript].into();
 
         let valid = lt_field_16_bit(array_index, parent_entry.num_children);
         let entry_index = (parent_entry.child_pointer + array_index) * valid as Field;
 
         let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(entry_index)].into();
-
-        assert(
-            (entry.entry_type - STRING_TOKEN as Field) * valid as Field == 0,
-            "get_array_element_as_string: entry exists but is not a string!",
-        );
+        if !valid {
+            assert_eq(
+                entry.entry_type,
+                STRING_TOKEN as Field,
+                "get_array_element_as_string: entry exists but is not a string!",
+            );
+        }
 
         let mut parsed_string: [u8; StringBytes] = self.extract_string_entry(entry);
 
@@ -422,7 +426,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         );
 
         let parent_entry: JSONEntry =
-            self.json_entries_packed[cast_num_to_u32(self.root_index_in_transcript)].into();
+            self.json_entries_packed[self.root_index_in_transcript].into();
 
         let valid = lt_field_16_bit(array_index, parent_entry.num_children);
         assert(valid, "array overflow");

--- a/src/getters.nr
+++ b/src/getters.nr
@@ -59,11 +59,8 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         // Safety: The assertion below checks that the keyhash is stored in the the index returned by the unconstrained function
         let key_index = unsafe { self.find_key_in_map(keyhash) };
 
-        assert(
-            self.key_hashes[cast_num_to_u32(key_index)] == keyhash,
-            "get_json_entry_unchecked: key not found",
-        );
-        let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(key_index)].into();
+        assert_eq(self.key_hashes[key_index], keyhash, "get_json_entry_unchecked: key not found");
+        let entry: JSONEntry = self.json_entries_packed[key_index].into();
 
         entry
     }
@@ -102,11 +99,8 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         // Safety: The assertion below checks that the keyhash is stored in the the index returned by the unconstrained function
         let key_index = unsafe { self.find_key_in_map(keyhash) };
 
-        assert(
-            self.key_hashes[cast_num_to_u32(key_index)] == keyhash,
-            "get_json_entry_unchecked: key not found",
-        );
-        let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(key_index)].into();
+        assert(self.key_hashes[key_index] == keyhash, "get_json_entry_unchecked: key not found");
+        let entry: JSONEntry = self.json_entries_packed[key_index].into();
 
         entry
     }
@@ -117,7 +111,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
     pub(crate) fn get_json_entry_unchecked_with_key_index<let KeyBytes: u32>(
         self,
         key: [u8; KeyBytes],
-    ) -> (JSONEntry, Field) {
+    ) -> (JSONEntry, u32) {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
 
         let hasher: ByteHasher<MaxKeyFields> = ByteHasher {};
@@ -129,11 +123,8 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         // Safety: The assertion below checks that the keyhash is stored in the the index returned by the unconstrained function
         let key_index = unsafe { self.find_key_in_map(keyhash) };
 
-        assert(
-            self.key_hashes[cast_num_to_u32(key_index)] == keyhash,
-            "get_json_entry_unchecked: key not found",
-        );
-        let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(key_index)].into();
+        assert(self.key_hashes[key_index] == keyhash, "get_json_entry_unchecked: key not found");
+        let entry: JSONEntry = self.json_entries_packed[key_index].into();
 
         (entry, key_index)
     }
@@ -143,7 +134,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
     pub(crate) fn get_json_entry_unchecked_with_key_index_var<let KeyBytes: u32>(
         self,
         key: BoundedVec<u8, KeyBytes>,
-    ) -> (JSONEntry, Field) {
+    ) -> (JSONEntry, u32) {
         assert(self.layer_type_of_root != ARRAY_LAYER, "cannot extract array elements via a key");
 
         let hasher: ByteHasher<MaxKeyFields> = ByteHasher {};
@@ -155,11 +146,8 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         // Safety: The assertion below checks that the keyhash is stored in the the index returned by the unconstrained function
         let key_index = unsafe { self.find_key_in_map(keyhash) };
 
-        assert(
-            self.key_hashes[cast_num_to_u32(key_index)] == keyhash,
-            "get_json_entry_unchecked: key not found",
-        );
-        let entry: JSONEntry = self.json_entries_packed[cast_num_to_u32(key_index)].into();
+        assert(self.key_hashes[key_index] == keyhash, "get_json_entry_unchecked: key not found");
+        let entry: JSONEntry = self.json_entries_packed[key_index].into();
 
         (entry, key_index)
     }
@@ -185,13 +173,13 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         result
     }
 
-    pub(crate) unconstrained fn find_key_in_map(self, target: Field) -> Field {
-        let mut found_index: Field = 0;
+    pub(crate) unconstrained fn find_key_in_map(self, target: Field) -> u32 {
+        let mut found_index: u32 = 0;
         let mut found: bool = false;
         for i in 0..MaxNumValues {
             let key_hash = self.key_hashes[i];
             if (key_hash == target) {
-                found_index = i as Field;
+                found_index = i;
                 found = true;
                 break;
             }
@@ -391,9 +379,8 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
     pub(crate) unconstrained fn __get_keys_at_root<let MaxNumKeys: u32>(
         self,
     ) -> BoundedVec<Field, MaxNumKeys> {
-        let root_object: JSONEntry = JSONEntry::from(
-            self.json_entries_packed[cast_num_to_u32(self.root_index_in_transcript)],
-        );
+        let root_object: JSONEntry =
+            JSONEntry::from(self.json_entries_packed[self.root_index_in_transcript]);
 
         let mut result_ptr = 0;
         let mut result: [Field; MaxNumKeys] = [0; MaxNumKeys];
@@ -412,9 +399,8 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
     pub(crate) fn get_keys_at_root<let MaxNumKeys: u32, let MaxKeyBytes: u32>(
         self,
     ) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
-        let root_object: JSONEntry = JSONEntry::from(
-            self.json_entries_packed[cast_num_to_u32(self.root_index_in_transcript)],
-        );
+        let root_object: JSONEntry =
+            JSONEntry::from(self.json_entries_packed[self.root_index_in_transcript]);
         // Safety: the length of the index is constrained later.
         let key_indices: BoundedVec<Field, MaxNumKeys> = unsafe { self.__get_keys_at_root() };
 

--- a/src/getters.nr
+++ b/src/getters.nr
@@ -99,7 +99,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         // Safety: The assertion below checks that the keyhash is stored in the the index returned by the unconstrained function
         let key_index = unsafe { self.find_key_in_map(keyhash) };
 
-        assert(self.key_hashes[key_index] == keyhash, "get_json_entry_unchecked: key not found");
+        assert_eq(self.key_hashes[key_index], keyhash, "get_json_entry_unchecked: key not found");
         let entry: JSONEntry = self.json_entries_packed[key_index].into();
 
         entry
@@ -123,7 +123,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         // Safety: The assertion below checks that the keyhash is stored in the the index returned by the unconstrained function
         let key_index = unsafe { self.find_key_in_map(keyhash) };
 
-        assert(self.key_hashes[key_index] == keyhash, "get_json_entry_unchecked: key not found");
+        assert_eq(self.key_hashes[key_index], keyhash, "get_json_entry_unchecked: key not found");
         let entry: JSONEntry = self.json_entries_packed[key_index].into();
 
         (entry, key_index)
@@ -146,7 +146,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         // Safety: The assertion below checks that the keyhash is stored in the the index returned by the unconstrained function
         let key_index = unsafe { self.find_key_in_map(keyhash) };
 
-        assert(self.key_hashes[key_index] == keyhash, "get_json_entry_unchecked: key not found");
+        assert_eq(self.key_hashes[key_index], keyhash, "get_json_entry_unchecked: key not found");
         let entry: JSONEntry = self.json_entries_packed[key_index].into();
 
         (entry, key_index)

--- a/src/json.nr
+++ b/src/json.nr
@@ -54,7 +54,7 @@ pub struct JSON<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u
     pub(crate) json_entries_packed: [JSONEntryPacked; MaxNumValues], // a sorted list of all the processed json values (objects, arrays, numerics, literals, strings)
     pub(crate) layer_type_of_root: u32, // is the root an OBJECT_LAYER, ARRAY_LAYER or SINGLE_VALUE_LAYER?
     pub(crate) root_id: Field, // the unique identifier of the root (if an object or array)
-    pub(crate) root_index_in_transcript: Field, // location in json_entries_packed of the root
+    pub(crate) root_index_in_transcript: u32, // location in json_entries_packed of the root
 }
 
 /**
@@ -266,13 +266,14 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
             tokens[i] = token;
             // 13 gates
             let TokenFlags {
-    create_json_entry,
-    is_end_of_object_or_array,
-    is_start_of_object_or_array,
-    new_context,
-    is_key_token: update_key,
-    is_value_token,
-    preserve_num_entries,} = TokenFlags::from_field(
+                create_json_entry,
+                is_end_of_object_or_array,
+                is_start_of_object_or_array,
+                new_context,
+                is_key_token: update_key,
+                is_value_token,
+                preserve_num_entries,
+            } = TokenFlags::from_field(
                 TOKEN_FLAGS_TABLE[cast_num_to_u32(token) + context * NUM_TOKENS],
             );
 
@@ -428,8 +429,12 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
 
             let encoded_ascii =
                 previous_was_potential_escape_sequence * 1024 + scan_mode * 256 + ascii as Field;
-            let ScanData { scan_token, push_transcript, increase_length, is_potential_escape_sequence } =
-                ScanData::from_field(JSON_CAPTURE_TABLE[cast_num_to_u32(encoded_ascii)]);
+            let ScanData {
+                scan_token,
+                push_transcript,
+                increase_length,
+                is_potential_escape_sequence,
+            } = ScanData::from_field(JSON_CAPTURE_TABLE[cast_num_to_u32(encoded_ascii)]);
 
             if push_transcript == 1 {
                 let new_entry = RawTranscriptEntry::to_field(
@@ -505,8 +510,12 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
             // 2 gates
             let capture_flags = JSON_CAPTURE_TABLE[cast_num_to_u32(encoded_ascii)];
             // 5 gates
-            let ScanData { scan_token, push_transcript, increase_length, is_potential_escape_sequence } =
-                ScanData::from_field(capture_flags);
+            let ScanData {
+                scan_token,
+                push_transcript,
+                increase_length,
+                is_potential_escape_sequence,
+            } = ScanData::from_field(capture_flags);
 
             // 2 gates
             let raw = raw_transcript[cast_num_to_u32(transcript_ptr)];

--- a/src/json.nr
+++ b/src/json.nr
@@ -266,14 +266,13 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
             tokens[i] = token;
             // 13 gates
             let TokenFlags {
-                create_json_entry,
-                is_end_of_object_or_array,
-                is_start_of_object_or_array,
-                new_context,
-                is_key_token: update_key,
-                is_value_token,
-                preserve_num_entries,
-            } = TokenFlags::from_field(
+    create_json_entry,
+    is_end_of_object_or_array,
+    is_start_of_object_or_array,
+    new_context,
+    is_key_token: update_key,
+    is_value_token,
+    preserve_num_entries,} = TokenFlags::from_field(
                 TOKEN_FLAGS_TABLE[cast_num_to_u32(token) + context * NUM_TOKENS],
             );
 
@@ -429,12 +428,8 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
 
             let encoded_ascii =
                 previous_was_potential_escape_sequence * 1024 + scan_mode * 256 + ascii as Field;
-            let ScanData {
-                scan_token,
-                push_transcript,
-                increase_length,
-                is_potential_escape_sequence,
-            } = ScanData::from_field(JSON_CAPTURE_TABLE[cast_num_to_u32(encoded_ascii)]);
+            let ScanData { scan_token, push_transcript, increase_length, is_potential_escape_sequence } =
+                ScanData::from_field(JSON_CAPTURE_TABLE[cast_num_to_u32(encoded_ascii)]);
 
             if push_transcript == 1 {
                 let new_entry = RawTranscriptEntry::to_field(
@@ -510,12 +505,8 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
             // 2 gates
             let capture_flags = JSON_CAPTURE_TABLE[cast_num_to_u32(encoded_ascii)];
             // 5 gates
-            let ScanData {
-                scan_token,
-                push_transcript,
-                increase_length,
-                is_potential_escape_sequence,
-            } = ScanData::from_field(capture_flags);
+            let ScanData { scan_token, push_transcript, increase_length, is_potential_escape_sequence } =
+                ScanData::from_field(capture_flags);
 
             // 2 gates
             let raw = raw_transcript[cast_num_to_u32(transcript_ptr)];

--- a/src/keymap.nr
+++ b/src/keymap.nr
@@ -138,12 +138,12 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         self.set_root_entry();
     }
 
-    pub(crate) unconstrained fn __find_root_entry(self) -> Field {
+    pub(crate) unconstrained fn __find_root_entry(self) -> u32 {
         let mut found_index = 0;
         for i in 0..MaxNumValues {
             let entry: JSONEntry = self.json_entries_packed[i].into();
             if (entry.parent_index == 0) & (self.json_entries_packed[i].value != 0) {
-                found_index = i as Field;
+                found_index = i;
                 break;
             }
         }
@@ -154,7 +154,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         // Safety: check the comments below
         let root_index = unsafe { self.__find_root_entry() };
 
-        let packed_entry = self.json_entries_packed[cast_num_to_u32(root_index)];
+        let packed_entry = self.json_entries_packed[root_index];
         let entry: JSONEntry = packed_entry.into();
 
         // checks that the entry is not empty


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR replaces `root_index_in_transcript` as being a `Field` with a `u32` so we can do less casting.

## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
