### PR TITLE
chore: fix inconsistent bit size for id field in JSONEntry

### DIFF
--- a/src/json_entry.nr
+++ b/src/json_entry.nr
@@ -125,7 +125,7 @@ impl JSONEntry {
         // Safety: we check all the outputs are in the correct range and we can construct the input from the outputs of the decomposition
         let (id, parent_index, mid, entry_type) =
             unsafe { JSONEntry::__extract_entry_type_id_and_parent_index_from_field(f) };
-        id.assert_max_bit_size::<8>(); // 1.25
+        id.assert_max_bit_size::<16>(); // 1.5
         parent_index.assert_max_bit_size::<16>(); // 1.5
         entry_type.assert_max_bit_size::<16>(); // 1.5
         mid.assert_max_bit_size::<136>(); // 5.5
@@ -141,7 +141,7 @@ impl JSONEntry {
     }
     fn extract_entry_type_and_id_from_field(f: Field) -> (Field, Field) {
         let (id, mid, entry_type) = unsafe { JSONEntry::__extract_entry_type_and_id_from_field(f) };
-        id.assert_max_bit_size::<8>(); // 1.25
+        id.assert_max_bit_size::<16>(); // 1.5
         entry_type.assert_max_bit_size::<16>(); // 1.5
         mid.assert_max_bit_size::<136>(); // 5.5
         assert(id + mid * 0x10000 + entry_type * 0x100000000000000000000000000000000000000 == f);


### PR DESCRIPTION
# Description

## Problem\*

closes https://github.com/noir-lang/noir_json_parser/issues/73

## Summary\*

standardizing the id field in JSONEntry to be 16 bits.

Currently, id is inconsistently treated as both 8-bit and 16-bit:

It's asserted as 8 bits in one place (id.assert_max_bit_size::<8>())
But constructed from two bytes (bytes[18] * 0x100 + bytes[19])
And later asserted as 16 bits (assert_max_bit_size::<16>())
This PR updates the code to consistently treat id as 16 bits.

There’s no strict requirement for it to be either 8 or 16, but 16 bits is more logical because:
The field is constructed from 2 bytes (bytes[18] * 0x100 + bytes[19])
The next element is offset by 2 bytes during field conversion: (self.current_identity
            + self.json_index * 0x10000
            + self.current_key_index_and_length * 0x100000000
            + self.num_entries * 0x10000000000000000
            + self.context * 0x100000000000000000000)
parent_index, which stores the id of another JSONEntry, is already 16 bits. We should keep it aligned


## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
