### PR TITLE
chore: remove methods from implementation

### DIFF
--- a/src/getters.nr
+++ b/src/getters.nr
@@ -337,7 +337,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
     }
 }
 
-pub(crate) unconstrained fn find_key_in_map<let MaxNumValues: u32>(
+unconstrained fn find_key_in_map<let MaxNumValues: u32>(
     key_hashes: [Field; MaxNumValues],
     target: Field,
 ) -> u32 {
@@ -361,7 +361,7 @@ pub(crate) unconstrained fn find_key_in_map<let MaxNumValues: u32>(
     *          entries in `self.key_hashes`, lhs_index, rhs_index, where
     *          lhs_index < key_hash < rhs_index
     **/
-pub(crate) unconstrained fn search_for_key_in_map<let MaxNumValues: u32>(
+unconstrained fn search_for_key_in_map<let MaxNumValues: u32>(
     key_hashes: [Field; MaxNumValues],
     target: Field,
 ) -> KeySearchResult {
@@ -418,7 +418,7 @@ pub(crate) unconstrained fn search_for_key_in_map<let MaxNumValues: u32>(
     }
 }
 
-pub(crate) unconstrained fn __get_keys_at_root<let MaxNumKeys: u32, let MaxNumValues: u32>(
+unconstrained fn __get_keys_at_root<let MaxNumKeys: u32, let MaxNumValues: u32>(
     root_id: Field,
     root_index_in_transcript: u32,
     json_entries_packed: [JSONEntryPacked; MaxNumValues],

--- a/src/getters.nr
+++ b/src/getters.nr
@@ -57,12 +57,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let keyhash = keyhash + self.root_id * two_pow_216;
 
         // Safety: The assertion below checks that the keyhash is stored in the the index returned by the unconstrained function
-        let key_index = unsafe {
-            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::find_key_in_map(
-                self.key_hashes,
-                keyhash,
-            )
-        };
+        let key_index = unsafe { find_key_in_map::<MaxNumValues>(self.key_hashes, keyhash) };
 
         assert_eq(self.key_hashes[key_index], keyhash, "get_json_entry_unchecked: key not found");
         let entry: JSONEntry = self.json_entries_packed[key_index].into();
@@ -102,12 +97,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let keyhash = keyhash + self.root_id * two_pow_216;
 
         // Safety: The assertion below checks that the keyhash is stored in the the index returned by the unconstrained function
-        let key_index = unsafe {
-            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::find_key_in_map(
-                self.key_hashes,
-                keyhash,
-            )
-        };
+        let key_index = unsafe { find_key_in_map::<MaxNumValues>(self.key_hashes, keyhash) };
 
         assert_eq(self.key_hashes[key_index], keyhash, "get_json_entry_unchecked: key not found");
         let entry: JSONEntry = self.json_entries_packed[key_index].into();
@@ -131,12 +121,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let keyhash = keyhash + self.root_id * two_pow_216;
 
         // Safety: The assertion below checks that the keyhash is stored in the the index returned by the unconstrained function
-        let key_index = unsafe {
-            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::find_key_in_map(
-                self.key_hashes,
-                keyhash,
-            )
-        };
+        let key_index = unsafe { find_key_in_map::<MaxNumValues>(self.key_hashes, keyhash) };
 
         assert_eq(self.key_hashes[key_index], keyhash, "get_json_entry_unchecked: key not found");
         let entry: JSONEntry = self.json_entries_packed[key_index].into();
@@ -159,12 +144,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let keyhash = keyhash + self.root_id * two_pow_216;
 
         // Safety: The assertion below checks that the keyhash is stored in the the index returned by the unconstrained function
-        let key_index = unsafe {
-            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::find_key_in_map(
-                self.key_hashes,
-                keyhash,
-            )
-        };
+        let key_index = unsafe { find_key_in_map::<MaxNumValues>(self.key_hashes, keyhash) };
 
         assert_eq(self.key_hashes[key_index], keyhash, "get_json_entry_unchecked: key not found");
         let entry: JSONEntry = self.json_entries_packed[key_index].into();
@@ -191,88 +171,6 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
             slice_string(self.json_packed, entry.json_pointer, entry.json_length);
 
         result
-    }
-
-    pub(crate) unconstrained fn find_key_in_map(
-        key_hashes: [Field; MaxNumValues],
-        target: Field,
-    ) -> u32 {
-        let mut found_index: u32 = 0;
-        let mut found: bool = false;
-        for i in 0..MaxNumValues {
-            let key_hash = key_hashes[i];
-            if (key_hash == target) {
-                found_index = i;
-                found = true;
-                break;
-            }
-        }
-        assert(found, "find_key_in_map, key not found");
-        found_index
-    }
-
-    /**
-     * @brief figures out if `target` exists as a key in `self.key_hashes`
-     * @details if `target` does not exist, we return the two indicies of adjacent
-     *          entries in `self.key_hashes`, lhs_index, rhs_index, where
-     *          lhs_index < key_hash < rhs_index
-     **/
-    pub(crate) unconstrained fn search_for_key_in_map(
-        key_hashes: [Field; MaxNumValues],
-        target: Field,
-    ) -> KeySearchResult {
-        let mut found_index: Field = 0;
-        let mut found: bool = false;
-
-        let mut lhs_maximum: Field = 0;
-        let mut rhs_minimum: Field = -1;
-        let mut lhs_maximum_index: Field = 0;
-        let mut rhs_minimum_index: Field = 0;
-        for i in 0..MaxNumValues {
-            let key_hash = key_hashes[i];
-            if (key_hash == target) {
-                found_index = i as Field;
-                found = true;
-                break;
-            } else {
-                if key_hash.lt(target) & (lhs_maximum.lt(key_hash)) {
-                    lhs_maximum = key_hash;
-                    lhs_maximum_index = i as Field;
-                }
-                if (target.lt(key_hash)) & (key_hash.lt(rhs_minimum)) {
-                    rhs_minimum = key_hash;
-                    rhs_minimum_index = i as Field;
-                }
-            }
-        }
-        let target_lt_smallest_entry = target.lt(key_hashes[0]);
-        let target_gt_largest_entry = key_hashes[MaxNumValues - 1].lt(target);
-
-        let result_not_first_or_last =
-            !target_lt_smallest_entry & !target_gt_largest_entry & !found;
-
-        let mut lhs_index = result_not_first_or_last as Field * lhs_maximum_index;
-        let mut rhs_index = result_not_first_or_last as Field * rhs_minimum_index;
-
-        // if target_lt_smallest_entry, rhs_index = 0
-        // if target_gt_largest_entry, lhs_index = TranscriptEntries - 1
-        rhs_index = rhs_index * (1 - target_lt_smallest_entry as Field);
-
-        // we rely here on the fact that target_gt_largest_entry and result_not_first_or_last are mutually exclusive
-        lhs_index = lhs_index + target_gt_largest_entry as Field * (MaxNumValues as Field - 1);
-
-        // If target is FOUND, we want the following:
-        // keyhash[target_index] - 1 < hash < keyhash[target_index] + 1
-        lhs_index = lhs_index + found as Field * found_index;
-        rhs_index = rhs_index + found as Field * found_index;
-
-        KeySearchResult {
-            found,
-            target_lt_smallest_entry,
-            target_gt_largest_entry,
-            lhs_index: lhs_index as u32,
-            rhs_index: rhs_index as u32,
-        }
     }
 
     /**
@@ -306,12 +204,8 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let keyhash = keyhash + self.root_id * two_pow_216;
 
         // Safety: The assertion below checks that the keyhash is stored in the the index returned by the unconstrained function
-        let search_result = unsafe {
-            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::search_for_key_in_map(
-                self.key_hashes,
-                keyhash,
-            )
-        };
+        let search_result =
+            unsafe { search_for_key_in_map::<MaxNumValues>(self.key_hashes, keyhash) };
         if search_result.found {
             assert_eq(search_result.lhs_index, search_result.rhs_index);
         }
@@ -373,12 +267,8 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let keyhash = keyhash + self.root_id * two_pow_216;
 
         // Safety: the assertion (search_result.lhs_index - search_result.rhs_index) * found == 0 constraints this function
-        let search_result = unsafe {
-            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::search_for_key_in_map(
-                self.key_hashes,
-                keyhash,
-            )
-        };
+        let search_result =
+            unsafe { search_for_key_in_map::<MaxNumValues>(self.key_hashes, keyhash) };
         if search_result.found {
             assert_eq(search_result.lhs_index, search_result.rhs_index);
         }
@@ -412,28 +302,6 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         (search_result.found, search_result.lhs_index)
     }
 
-    pub(crate) unconstrained fn __get_keys_at_root<let MaxNumKeys: u32>(
-        root_id: Field,
-        root_index_in_transcript: u32,
-        json_entries_packed: [JSONEntryPacked; MaxNumValues],
-        unsorted_json_entries_packed: [JSONEntryPacked; MaxNumValues],
-    ) -> BoundedVec<Field, MaxNumKeys> {
-        let root_object: JSONEntry = JSONEntry::from(json_entries_packed[root_index_in_transcript]);
-
-        let mut result_ptr = 0;
-        let mut result: [Field; MaxNumKeys] = [0; MaxNumKeys];
-        for i in 0..MaxNumValues {
-            let target_entry: JSONEntry = JSONEntry::from(unsorted_json_entries_packed[i]);
-            if (target_entry.parent_index == root_id) {
-                result[result_ptr] = i as Field;
-                result_ptr += 1;
-            }
-        }
-        assert_eq(result_ptr as Field, root_object.num_children);
-
-        BoundedVec::from_parts_unchecked(result, result_ptr as u32)
-    }
-
     pub(crate) fn get_keys_at_root<let MaxNumKeys: u32, let MaxKeyBytes: u32>(
         self,
     ) -> BoundedVec<BoundedVec<u8, MaxKeyBytes>, MaxNumKeys> {
@@ -441,7 +309,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
             JSONEntry::from(self.json_entries_packed[self.root_index_in_transcript]);
         // Safety: the length of the index is constrained later.
         let key_indices: BoundedVec<Field, MaxNumKeys> = unsafe {
-            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::__get_keys_at_root(
+            __get_keys_at_root::<MaxNumKeys, MaxNumValues>(
                 self.root_id,
                 self.root_index_in_transcript,
                 self.json_entries_packed,
@@ -467,6 +335,109 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         }
         BoundedVec::from_parts_unchecked(result, key_indices.len())
     }
+}
+
+pub(crate) unconstrained fn find_key_in_map<let MaxNumValues: u32>(
+    key_hashes: [Field; MaxNumValues],
+    target: Field,
+) -> u32 {
+    let mut found_index: u32 = 0;
+    let mut found: bool = false;
+    for i in 0..MaxNumValues {
+        let key_hash = key_hashes[i];
+        if (key_hash == target) {
+            found_index = i;
+            found = true;
+            break;
+        }
+    }
+    assert(found, "find_key_in_map, key not found");
+    found_index
+}
+
+/**
+    * @brief figures out if `target` exists as a key in `self.key_hashes`
+    * @details if `target` does not exist, we return the two indicies of adjacent
+    *          entries in `self.key_hashes`, lhs_index, rhs_index, where
+    *          lhs_index < key_hash < rhs_index
+    **/
+pub(crate) unconstrained fn search_for_key_in_map<let MaxNumValues: u32>(
+    key_hashes: [Field; MaxNumValues],
+    target: Field,
+) -> KeySearchResult {
+    let mut found_index: Field = 0;
+    let mut found: bool = false;
+
+    let mut lhs_maximum: Field = 0;
+    let mut rhs_minimum: Field = -1;
+    let mut lhs_maximum_index: Field = 0;
+    let mut rhs_minimum_index: Field = 0;
+    for i in 0..MaxNumValues {
+        let key_hash = key_hashes[i];
+        if (key_hash == target) {
+            found_index = i as Field;
+            found = true;
+            break;
+        } else {
+            if key_hash.lt(target) & (lhs_maximum.lt(key_hash)) {
+                lhs_maximum = key_hash;
+                lhs_maximum_index = i as Field;
+            }
+            if (target.lt(key_hash)) & (key_hash.lt(rhs_minimum)) {
+                rhs_minimum = key_hash;
+                rhs_minimum_index = i as Field;
+            }
+        }
+    }
+    let target_lt_smallest_entry = target.lt(key_hashes[0]);
+    let target_gt_largest_entry = key_hashes[MaxNumValues - 1].lt(target);
+
+    let result_not_first_or_last = !target_lt_smallest_entry & !target_gt_largest_entry & !found;
+
+    let mut lhs_index = result_not_first_or_last as Field * lhs_maximum_index;
+    let mut rhs_index = result_not_first_or_last as Field * rhs_minimum_index;
+
+    // if target_lt_smallest_entry, rhs_index = 0
+    // if target_gt_largest_entry, lhs_index = TranscriptEntries - 1
+    rhs_index = rhs_index * (1 - target_lt_smallest_entry as Field);
+
+    // we rely here on the fact that target_gt_largest_entry and result_not_first_or_last are mutually exclusive
+    lhs_index = lhs_index + target_gt_largest_entry as Field * (MaxNumValues as Field - 1);
+
+    // If target is FOUND, we want the following:
+    // keyhash[target_index] - 1 < hash < keyhash[target_index] + 1
+    lhs_index = lhs_index + found as Field * found_index;
+    rhs_index = rhs_index + found as Field * found_index;
+
+    KeySearchResult {
+        found,
+        target_lt_smallest_entry,
+        target_gt_largest_entry,
+        lhs_index: lhs_index as u32,
+        rhs_index: rhs_index as u32,
+    }
+}
+
+pub(crate) unconstrained fn __get_keys_at_root<let MaxNumKeys: u32, let MaxNumValues: u32>(
+    root_id: Field,
+    root_index_in_transcript: u32,
+    json_entries_packed: [JSONEntryPacked; MaxNumValues],
+    unsorted_json_entries_packed: [JSONEntryPacked; MaxNumValues],
+) -> BoundedVec<Field, MaxNumKeys> {
+    let root_object: JSONEntry = JSONEntry::from(json_entries_packed[root_index_in_transcript]);
+
+    let mut result_ptr = 0;
+    let mut result: [Field; MaxNumKeys] = [0; MaxNumKeys];
+    for i in 0..MaxNumValues {
+        let target_entry: JSONEntry = JSONEntry::from(unsorted_json_entries_packed[i]);
+        if (target_entry.parent_index == root_id) {
+            result[result_ptr] = i as Field;
+            result_ptr += 1;
+        }
+    }
+    assert_eq(result_ptr as Field, root_object.num_children);
+
+    BoundedVec::from_parts_unchecked(result, result_ptr as u32)
 }
 
 #[test]

--- a/src/getters.nr
+++ b/src/getters.nr
@@ -2,7 +2,7 @@ use crate::_comparison_tools::lt::{assert_gt_240_bit, assert_lt_240_bit, lt_fiel
 use crate::_string_tools::string_chopper::slice_string;
 use crate::enums::Layer::ARRAY_LAYER;
 use crate::json::JSON;
-use crate::json_entry::JSONEntry;
+use crate::json_entry::{JSONEntry, JSONEntryPacked};
 use crate::keyhash::ByteHasher;
 use crate::keymap::KeyIndexData;
 use crate::utils::cast_num_to_u32;
@@ -57,7 +57,12 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let keyhash = keyhash + self.root_id * two_pow_216;
 
         // Safety: The assertion below checks that the keyhash is stored in the the index returned by the unconstrained function
-        let key_index = unsafe { self.find_key_in_map(keyhash) };
+        let key_index = unsafe {
+            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::find_key_in_map(
+                self.key_hashes,
+                keyhash,
+            )
+        };
 
         assert_eq(self.key_hashes[key_index], keyhash, "get_json_entry_unchecked: key not found");
         let entry: JSONEntry = self.json_entries_packed[key_index].into();
@@ -97,7 +102,12 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let keyhash = keyhash + self.root_id * two_pow_216;
 
         // Safety: The assertion below checks that the keyhash is stored in the the index returned by the unconstrained function
-        let key_index = unsafe { self.find_key_in_map(keyhash) };
+        let key_index = unsafe {
+            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::find_key_in_map(
+                self.key_hashes,
+                keyhash,
+            )
+        };
 
         assert_eq(self.key_hashes[key_index], keyhash, "get_json_entry_unchecked: key not found");
         let entry: JSONEntry = self.json_entries_packed[key_index].into();
@@ -121,7 +131,12 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let keyhash = keyhash + self.root_id * two_pow_216;
 
         // Safety: The assertion below checks that the keyhash is stored in the the index returned by the unconstrained function
-        let key_index = unsafe { self.find_key_in_map(keyhash) };
+        let key_index = unsafe {
+            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::find_key_in_map(
+                self.key_hashes,
+                keyhash,
+            )
+        };
 
         assert_eq(self.key_hashes[key_index], keyhash, "get_json_entry_unchecked: key not found");
         let entry: JSONEntry = self.json_entries_packed[key_index].into();
@@ -144,7 +159,12 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let keyhash = keyhash + self.root_id * two_pow_216;
 
         // Safety: The assertion below checks that the keyhash is stored in the the index returned by the unconstrained function
-        let key_index = unsafe { self.find_key_in_map(keyhash) };
+        let key_index = unsafe {
+            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::find_key_in_map(
+                self.key_hashes,
+                keyhash,
+            )
+        };
 
         assert_eq(self.key_hashes[key_index], keyhash, "get_json_entry_unchecked: key not found");
         let entry: JSONEntry = self.json_entries_packed[key_index].into();
@@ -173,11 +193,14 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         result
     }
 
-    pub(crate) unconstrained fn find_key_in_map(self, target: Field) -> u32 {
+    pub(crate) unconstrained fn find_key_in_map(
+        key_hashes: [Field; MaxNumValues],
+        target: Field,
+    ) -> u32 {
         let mut found_index: u32 = 0;
         let mut found: bool = false;
         for i in 0..MaxNumValues {
-            let key_hash = self.key_hashes[i];
+            let key_hash = key_hashes[i];
             if (key_hash == target) {
                 found_index = i;
                 found = true;
@@ -194,7 +217,10 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
      *          entries in `self.key_hashes`, lhs_index, rhs_index, where
      *          lhs_index < key_hash < rhs_index
      **/
-    pub(crate) unconstrained fn search_for_key_in_map(self, target: Field) -> KeySearchResult {
+    pub(crate) unconstrained fn search_for_key_in_map(
+        key_hashes: [Field; MaxNumValues],
+        target: Field,
+    ) -> KeySearchResult {
         let mut found_index: Field = 0;
         let mut found: bool = false;
 
@@ -203,7 +229,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let mut lhs_maximum_index: Field = 0;
         let mut rhs_minimum_index: Field = 0;
         for i in 0..MaxNumValues {
-            let key_hash = self.key_hashes[i];
+            let key_hash = key_hashes[i];
             if (key_hash == target) {
                 found_index = i as Field;
                 found = true;
@@ -219,8 +245,8 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
                 }
             }
         }
-        let target_lt_smallest_entry = target.lt(self.key_hashes[0]);
-        let target_gt_largest_entry = self.key_hashes[MaxNumValues - 1].lt(target);
+        let target_lt_smallest_entry = target.lt(key_hashes[0]);
+        let target_gt_largest_entry = key_hashes[MaxNumValues - 1].lt(target);
 
         let result_not_first_or_last =
             !target_lt_smallest_entry & !target_gt_largest_entry & !found;
@@ -280,7 +306,12 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let keyhash = keyhash + self.root_id * two_pow_216;
 
         // Safety: The assertion below checks that the keyhash is stored in the the index returned by the unconstrained function
-        let search_result = unsafe { self.search_for_key_in_map(keyhash) };
+        let search_result = unsafe {
+            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::search_for_key_in_map(
+                self.key_hashes,
+                keyhash,
+            )
+        };
         if search_result.found {
             assert_eq(search_result.lhs_index, search_result.rhs_index);
         }
@@ -342,7 +373,12 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let keyhash = keyhash + self.root_id * two_pow_216;
 
         // Safety: the assertion (search_result.lhs_index - search_result.rhs_index) * found == 0 constraints this function
-        let search_result = unsafe { self.search_for_key_in_map(keyhash) };
+        let search_result = unsafe {
+            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::search_for_key_in_map(
+                self.key_hashes,
+                keyhash,
+            )
+        };
         if search_result.found {
             assert_eq(search_result.lhs_index, search_result.rhs_index);
         }
@@ -377,16 +413,18 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
     }
 
     pub(crate) unconstrained fn __get_keys_at_root<let MaxNumKeys: u32>(
-        self,
+        root_id: Field,
+        root_index_in_transcript: u32,
+        json_entries_packed: [JSONEntryPacked; MaxNumValues],
+        unsorted_json_entries_packed: [JSONEntryPacked; MaxNumValues],
     ) -> BoundedVec<Field, MaxNumKeys> {
-        let root_object: JSONEntry =
-            JSONEntry::from(self.json_entries_packed[self.root_index_in_transcript]);
+        let root_object: JSONEntry = JSONEntry::from(json_entries_packed[root_index_in_transcript]);
 
         let mut result_ptr = 0;
         let mut result: [Field; MaxNumKeys] = [0; MaxNumKeys];
         for i in 0..MaxNumValues {
-            let target_entry: JSONEntry = JSONEntry::from(self.unsorted_json_entries_packed[i]);
-            if (target_entry.parent_index == self.root_id) {
+            let target_entry: JSONEntry = JSONEntry::from(unsorted_json_entries_packed[i]);
+            if (target_entry.parent_index == root_id) {
                 result[result_ptr] = i as Field;
                 result_ptr += 1;
             }
@@ -402,7 +440,14 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let root_object: JSONEntry =
             JSONEntry::from(self.json_entries_packed[self.root_index_in_transcript]);
         // Safety: the length of the index is constrained later.
-        let key_indices: BoundedVec<Field, MaxNumKeys> = unsafe { self.__get_keys_at_root() };
+        let key_indices: BoundedVec<Field, MaxNumKeys> = unsafe {
+            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::__get_keys_at_root(
+                self.root_id,
+                self.root_index_in_transcript,
+                self.json_entries_packed,
+                self.unsorted_json_entries_packed,
+            )
+        };
 
         assert(key_indices.len() as Field == root_object.num_children);
 

--- a/src/json.nr
+++ b/src/json.nr
@@ -423,7 +423,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let mut length: Field = 0;
         let mut previous_was_potential_escape_sequence: bool = false;
         for i in 0..NumBytes {
-            // while this assert is in an unconstrained function, the out of bounds accesss `raw_transcript[transcript_ptr]` in build_transcript also generates failing constraints
+            // while this assert is in an unconstrained function, the out of bounds access `raw_transcript[transcript_ptr]` in build_transcript also generates failing constraints
             assert(transcript_ptr < MaxNumTokens, "build_transcript: MaxNumTokens limit exceeded!");
             let ascii = json_array[i];
 
@@ -492,7 +492,11 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let mut length: Field = 0;
 
         // Safety: check the comments below
-        let raw_transcript = unsafe { JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::__build_transcript(self.json) };
+        let raw_transcript = unsafe {
+            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::__build_transcript(
+                self.json,
+            )
+        };
 
         // 14 gates per iteration, plus fixed cost for initing 2,048 size lookup table (4,096 gates)
         let mut previous_was_potential_escape_sequence: bool = false;
@@ -560,7 +564,10 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
      * @brief We compute the output of `capture_missing_tokens` via an unconstrained function, then validate the result is correct.
      *        Saves some gates for same reason as in __build_transcript
      **/
-    unconstrained fn __capture_missing_tokens(raw_transcript: [Field; MaxNumTokens], transcript_length: u32) -> [Field; MaxNumTokens] {
+    unconstrained fn __capture_missing_tokens(
+        raw_transcript: [Field; MaxNumTokens],
+        transcript_length: u32,
+    ) -> [Field; MaxNumTokens] {
         let mut updated_transcript: [Field; MaxNumTokens] = [0; MaxNumTokens];
         let mut transcript_ptr: u32 = 0;
         // TODO: do we need a null transcript value?!?!
@@ -604,7 +611,12 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let mut transcript_ptr: Field = 0;
         // hmm probably need a null transcript value?!?!
         // Safety: check the comments below
-        let updated_transcript = unsafe { JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::__capture_missing_tokens(self.raw_transcript, self.transcript_length) };
+        let updated_transcript = unsafe {
+            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::__capture_missing_tokens(
+                self.raw_transcript,
+                self.transcript_length,
+            )
+        };
         // 26? gates per iteration
         let range_valid: [u32; MaxNumTokens] = get_validity_flags(self.transcript_length);
         for i in 0..MaxNumTokens {

--- a/src/json.nr
+++ b/src/json.nr
@@ -416,7 +416,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
      *        because we can use ROM arrays instead of RAM arrays
      *        (i.e. we're only reading from our arrays, we don't write to them in constrained functions)
      **/
-    unconstrained fn __build_transcript(self) -> [Field; MaxNumTokens] {
+    unconstrained fn __build_transcript(json_array: [u8; NumBytes]) -> [Field; MaxNumTokens] {
         let mut raw_transcript: [Field; MaxNumTokens] = [0; MaxNumTokens];
         let mut transcript_ptr: u32 = 0;
         let mut scan_mode = GRAMMAR_CAPTURE;
@@ -425,7 +425,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         for i in 0..NumBytes {
             // while this assert is in an unconstrained function, the out of bounds accesss `raw_transcript[transcript_ptr]` in build_transcript also generates failing constraints
             assert(transcript_ptr < MaxNumTokens, "build_transcript: MaxNumTokens limit exceeded!");
-            let ascii = self.json[i];
+            let ascii = json_array[i];
 
             let encoded_ascii = previous_was_potential_escape_sequence as Field * 1024
                 + scan_mode * 256
@@ -492,7 +492,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let mut length: Field = 0;
 
         // Safety: check the comments below
-        let raw_transcript = unsafe { self.__build_transcript() };
+        let raw_transcript = unsafe { JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::__build_transcript(self.json) };
 
         // 14 gates per iteration, plus fixed cost for initing 2,048 size lookup table (4,096 gates)
         let mut previous_was_potential_escape_sequence: bool = false;
@@ -560,13 +560,13 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
      * @brief We compute the output of `capture_missing_tokens` via an unconstrained function, then validate the result is correct.
      *        Saves some gates for same reason as in __build_transcript
      **/
-    unconstrained fn __capture_missing_tokens(self) -> [Field; MaxNumTokens] {
+    unconstrained fn __capture_missing_tokens(raw_transcript: [Field; MaxNumTokens], transcript_length: u32) -> [Field; MaxNumTokens] {
         let mut updated_transcript: [Field; MaxNumTokens] = [0; MaxNumTokens];
         let mut transcript_ptr: u32 = 0;
         // TODO: do we need a null transcript value?!?!
         for i in 0..MaxNumTokens {
             let RawTranscriptEntry { encoded_ascii, index, length } =
-                RawTranscriptEntry::from_field(self.raw_transcript[i]);
+                RawTranscriptEntry::from_field(raw_transcript[i]);
 
             let PostProcessScanData { token, new_grammar, scan_token } = PostProcessScanData::from_field(
                 PROCESS_RAW_TRANSCRIPT_TABLE[cast_num_to_u32(encoded_ascii)],
@@ -575,7 +575,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
             let entry = TranscriptEntry::to_field(TranscriptEntry { token, index, length });
             updated_transcript[transcript_ptr] = entry;
 
-            let index_valid: u32 = (i < self.transcript_length) as u32;
+            let index_valid: u32 = (i < transcript_length) as u32;
             transcript_ptr += index_valid;
 
             let index_of_possible_grammar = (index + length);
@@ -604,7 +604,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let mut transcript_ptr: Field = 0;
         // hmm probably need a null transcript value?!?!
         // Safety: check the comments below
-        let updated_transcript = unsafe { self.__capture_missing_tokens() };
+        let updated_transcript = unsafe { JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::__capture_missing_tokens(self.raw_transcript, self.transcript_length) };
         // 26? gates per iteration
         let range_valid: [u32; MaxNumTokens] = get_validity_flags(self.transcript_length);
         for i in 0..MaxNumTokens {

--- a/src/json.nr
+++ b/src/json.nr
@@ -410,59 +410,6 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
     }
 
     /**
-     * @brief Perform the 1st transcript processing step as an unconstrained function
-     *        We will validate this transcript is correct via a constrained function
-     *        This is a bit cheaper than doing everything in a constrained function,
-     *        because we can use ROM arrays instead of RAM arrays
-     *        (i.e. we're only reading from our arrays, we don't write to them in constrained functions)
-     **/
-    unconstrained fn __build_transcript(json_array: [u8; NumBytes]) -> [Field; MaxNumTokens] {
-        let mut raw_transcript: [Field; MaxNumTokens] = [0; MaxNumTokens];
-        let mut transcript_ptr: u32 = 0;
-        let mut scan_mode = GRAMMAR_CAPTURE;
-        let mut length: Field = 0;
-        let mut previous_was_potential_escape_sequence: bool = false;
-        for i in 0..NumBytes {
-            // while this assert is in an unconstrained function, the out of bounds access `raw_transcript[transcript_ptr]` in build_transcript also generates failing constraints
-            assert(transcript_ptr < MaxNumTokens, "build_transcript: MaxNumTokens limit exceeded!");
-            let ascii = json_array[i];
-
-            let encoded_ascii = previous_was_potential_escape_sequence as Field * 1024
-                + scan_mode * 256
-                + ascii as Field;
-            let ScanData { scan_token, push_transcript, increase_length, is_potential_escape_sequence } =
-                ScanData::from_field(JSON_CAPTURE_TABLE[cast_num_to_u32(encoded_ascii)]);
-
-            if push_transcript {
-                let new_entry = RawTranscriptEntry::to_field(
-                    RawTranscriptEntry { encoded_ascii, index: i as Field - length, length },
-                );
-
-                raw_transcript[transcript_ptr] = new_entry;
-                transcript_ptr += 1;
-                length = increase_length as Field;
-            } else {
-                length += increase_length as Field;
-            }
-
-            previous_was_potential_escape_sequence = is_potential_escape_sequence;
-
-            scan_mode = scan_token;
-        }
-
-        // if we end in a scan mode where we're searching for a number, string or a literal (true/false/null), we have an incomplete token and this is invalid JSON
-        // NOTE: if we upgrade this parser to be able to process single-value JSON (e,g, "999" or ""hello" : "world"" this logic needs to be upgraded)
-        assert(
-            scan_mode == GRAMMAR_CAPTURE as Field,
-            "build_transcript: incomplete token (number, string or literal)",
-        );
-
-        // ensure an error isn't hiding in the last scanned token
-        scan_mode.assert_max_bit_size::<2>();
-        raw_transcript
-    }
-
-    /**
      * @brief Construct a token transcript by iterating through self.json and using a lookup table `JSON_CAPTURE_TABLE` to define a state transition function
      * @details JSON_CAPTURE_TABLE takes the following as input:
      *          1. the ascii byte at the current location in the json
@@ -492,11 +439,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let mut length: Field = 0;
 
         // Safety: check the comments below
-        let raw_transcript = unsafe {
-            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::__build_transcript(
-                self.json,
-            )
-        };
+        let raw_transcript = unsafe { __build_transcript::<NumBytes, MaxNumTokens>(self.json) };
 
         // 14 gates per iteration, plus fixed cost for initing 2,048 size lookup table (4,096 gates)
         let mut previous_was_potential_escape_sequence: bool = false;
@@ -561,47 +504,6 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
     }
 
     /**
-     * @brief We compute the output of `capture_missing_tokens` via an unconstrained function, then validate the result is correct.
-     *        Saves some gates for same reason as in __build_transcript
-     **/
-    unconstrained fn __capture_missing_tokens(
-        raw_transcript: [Field; MaxNumTokens],
-        transcript_length: u32,
-    ) -> [Field; MaxNumTokens] {
-        let mut updated_transcript: [Field; MaxNumTokens] = [0; MaxNumTokens];
-        let mut transcript_ptr: u32 = 0;
-        // TODO: do we need a null transcript value?!?!
-        for i in 0..MaxNumTokens {
-            let RawTranscriptEntry { encoded_ascii, index, length } =
-                RawTranscriptEntry::from_field(raw_transcript[i]);
-
-            let PostProcessScanData { token, new_grammar, scan_token } = PostProcessScanData::from_field(
-                PROCESS_RAW_TRANSCRIPT_TABLE[cast_num_to_u32(encoded_ascii)],
-            );
-
-            let entry = TranscriptEntry::to_field(TranscriptEntry { token, index, length });
-            updated_transcript[transcript_ptr] = entry;
-
-            let index_valid: u32 = (i < transcript_length) as u32;
-            transcript_ptr += index_valid;
-
-            let index_of_possible_grammar = (index + length);
-            let new_entry =
-                TranscriptEntry { token: scan_token, index: index_of_possible_grammar, length: 0 };
-
-            let update = new_grammar * index_valid as Field;
-            let new_transcript = TranscriptEntry::to_field(new_entry);
-            assert(
-                transcript_ptr < MaxNumTokens,
-                "capture_missing_tokens: MaxNumTokens limit exceeded!",
-            );
-            updated_transcript[transcript_ptr] = new_transcript;
-            transcript_ptr += (update != 0) as u32;
-        }
-        updated_transcript
-    }
-
-    /**
      * @brief Check for missing tokens that we could have missed in `build_transcript`
      * @details If we had a json string where a NUMERIC_TOKEN or LITERAL_TOKEN is directly succeeded by a VALUE_SEPARATOR_TOKEN, END_OBJECT_TOKEN, END_ARRAY_TOKEN,
      *          we will have missed the latter token.
@@ -612,10 +514,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         // hmm probably need a null transcript value?!?!
         // Safety: check the comments below
         let updated_transcript = unsafe {
-            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::__capture_missing_tokens(
-                self.raw_transcript,
-                self.transcript_length,
-            )
+            __capture_missing_tokens::<MaxNumTokens>(self.raw_transcript, self.transcript_length)
         };
         // 26? gates per iteration
         let range_valid: [u32; MaxNumTokens] = get_validity_flags(self.transcript_length);
@@ -748,6 +647,102 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
 //     assert(json.get_length() == 0);
 //     assert(json.get_array_element_as_number(0) == 100);
 // }
+
+/**
+    * @brief Perform the 1st transcript processing step as an unconstrained function
+    *        We will validate this transcript is correct via a constrained function
+    *        This is a bit cheaper than doing everything in a constrained function,
+    *        because we can use ROM arrays instead of RAM arrays
+    *        (i.e. we're only reading from our arrays, we don't write to them in constrained functions)
+    **/
+unconstrained fn __build_transcript<let NumBytes: u32, let MaxNumTokens: u32>(
+    json_array: [u8; NumBytes],
+) -> [Field; MaxNumTokens] {
+    let mut raw_transcript: [Field; MaxNumTokens] = [0; MaxNumTokens];
+    let mut transcript_ptr: u32 = 0;
+    let mut scan_mode = GRAMMAR_CAPTURE;
+    let mut length: Field = 0;
+    let mut previous_was_potential_escape_sequence: bool = false;
+    for i in 0..NumBytes {
+        // while this assert is in an unconstrained function, the out of bounds access `raw_transcript[transcript_ptr]` in build_transcript also generates failing constraints
+        assert(transcript_ptr < MaxNumTokens, "build_transcript: MaxNumTokens limit exceeded!");
+        let ascii = json_array[i];
+
+        let encoded_ascii = previous_was_potential_escape_sequence as Field * 1024
+            + scan_mode * 256
+            + ascii as Field;
+        let ScanData { scan_token, push_transcript, increase_length, is_potential_escape_sequence } =
+            ScanData::from_field(JSON_CAPTURE_TABLE[cast_num_to_u32(encoded_ascii)]);
+
+        if push_transcript {
+            let new_entry = RawTranscriptEntry::to_field(
+                RawTranscriptEntry { encoded_ascii, index: i as Field - length, length },
+            );
+
+            raw_transcript[transcript_ptr] = new_entry;
+            transcript_ptr += 1;
+            length = increase_length as Field;
+        } else {
+            length += increase_length as Field;
+        }
+
+        previous_was_potential_escape_sequence = is_potential_escape_sequence;
+
+        scan_mode = scan_token;
+    }
+
+    // if we end in a scan mode where we're searching for a number, string or a literal (true/false/null), we have an incomplete token and this is invalid JSON
+    // NOTE: if we upgrade this parser to be able to process single-value JSON (e,g, "999" or ""hello" : "world"" this logic needs to be upgraded)
+    assert(
+        scan_mode == GRAMMAR_CAPTURE as Field,
+        "build_transcript: incomplete token (number, string or literal)",
+    );
+
+    // ensure an error isn't hiding in the last scanned token
+    scan_mode.assert_max_bit_size::<2>();
+    raw_transcript
+}
+
+/**
+    * @brief We compute the output of `capture_missing_tokens` via an unconstrained function, then validate the result is correct.
+    *        Saves some gates for same reason as in __build_transcript
+    **/
+unconstrained fn __capture_missing_tokens<let MaxNumTokens: u32>(
+    raw_transcript: [Field; MaxNumTokens],
+    transcript_length: u32,
+) -> [Field; MaxNumTokens] {
+    let mut updated_transcript: [Field; MaxNumTokens] = [0; MaxNumTokens];
+    let mut transcript_ptr: u32 = 0;
+    // TODO: do we need a null transcript value?!?!
+    for i in 0..MaxNumTokens {
+        let RawTranscriptEntry { encoded_ascii, index, length } =
+            RawTranscriptEntry::from_field(raw_transcript[i]);
+
+        let PostProcessScanData { token, new_grammar, scan_token } = PostProcessScanData::from_field(
+            PROCESS_RAW_TRANSCRIPT_TABLE[cast_num_to_u32(encoded_ascii)],
+        );
+
+        let entry = TranscriptEntry::to_field(TranscriptEntry { token, index, length });
+        updated_transcript[transcript_ptr] = entry;
+
+        let index_valid: u32 = (i < transcript_length) as u32;
+        transcript_ptr += index_valid;
+
+        let index_of_possible_grammar = (index + length);
+        let new_entry =
+            TranscriptEntry { token: scan_token, index: index_of_possible_grammar, length: 0 };
+
+        let update = new_grammar * index_valid as Field;
+        let new_transcript = TranscriptEntry::to_field(new_entry);
+        assert(
+            transcript_ptr < MaxNumTokens,
+            "capture_missing_tokens: MaxNumTokens limit exceeded!",
+        );
+        updated_transcript[transcript_ptr] = new_transcript;
+        transcript_ptr += (update != 0) as u32;
+    }
+    updated_transcript
+}
 
 #[test]
 fn test_numbers() {

--- a/src/keymap.nr
+++ b/src/keymap.nr
@@ -132,27 +132,9 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         self.set_root_entry();
     }
 
-    pub(crate) unconstrained fn __find_root_entry(
-        json_entries_packed: [JSONEntryPacked; MaxNumValues],
-    ) -> u32 {
-        let mut found_index = 0;
-        for i in 0..MaxNumValues {
-            let entry: JSONEntry = json_entries_packed[i].into();
-            if (entry.parent_index == 0) & (json_entries_packed[i].value != 0) {
-                found_index = i;
-                break;
-            }
-        }
-        found_index
-    }
-
     pub(crate) fn set_root_entry(&mut self) {
         // Safety: check the comments below
-        let root_index = unsafe {
-            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::__find_root_entry(
-                self.json_entries_packed,
-            )
-        };
+        let root_index = unsafe { __find_root_entry::<MaxNumValues>(self.json_entries_packed) };
 
         let packed_entry = self.json_entries_packed[root_index];
         let entry: JSONEntry = packed_entry.into();
@@ -165,4 +147,16 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
     }
 }
 
-// 68002
+unconstrained fn __find_root_entry<let MaxNumValues: u32>(
+    json_entries_packed: [JSONEntryPacked; MaxNumValues],
+) -> u32 {
+    let mut found_index = 0;
+    for i in 0..MaxNumValues {
+        let entry: JSONEntry = json_entries_packed[i].into();
+        if (entry.parent_index == 0) & (json_entries_packed[i].value != 0) {
+            found_index = i;
+            break;
+        }
+    }
+    found_index
+}

--- a/src/keymap.nr
+++ b/src/keymap.nr
@@ -1,5 +1,4 @@
 use crate::_comparison_tools::lt::assert_lte_240_bit;
-use crate::_comparison_tools::lt::lt_field_16_bit;
 use crate::_comparison_tools::lt::lte_field_240_bit;
 use crate::json::JSON;
 use crate::json_entry::{JSONEntry, JSONEntryPacked};
@@ -62,6 +61,7 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
             let KeyIndexData { json_index, json_length, parent_id, array_index } =
                 KeyIndexData::from_field(self.key_data[i]);
             let hash = hasher.get_keyhash(self.json_packed, json_index, json_length);
+            //ensures hash:0-199 bits, array_index:200-215 bits, parent_id: 216-239 bits
             hashlist[i] = hash + array_index * two_pow_200 + parent_id * two_pow_216;
         }
 
@@ -72,69 +72,60 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
 
         let mut sorted_entries: [JSONEntryPacked; MaxNumValues] =
             [JSONEntryPacked::default(); MaxNumValues];
+
         for i in 0..MaxNumValues {
             sorted_entries[sort_result.sort_indices[i]] = self.json_entries_packed[i];
         }
 
-        let mut ids: [Field; MaxNumValues] = [0; MaxNumValues];
-        let mut parent_indices: [Field; MaxNumValues] = [0; MaxNumValues];
-        let mut entry_types: [Field; MaxNumValues] = [0; MaxNumValues];
+        let mut parent_indices: [u32; MaxNumValues] = [0; MaxNumValues];
 
+        let mut identity_to_json_map: [u32; MaxNumValues] = [0; MaxNumValues];
         for i in 0..MaxNumValues {
             // 11.75 + 3.5 = 15.25 gates per iteration
             let (id, parent_index, entry_type) = JSONEntry::extract_entry_type_id_and_parent_index_from_field(
                 sorted_entries[i].value,
             );
-            ids[i] = id;
-            parent_indices[i] = parent_index;
-            entry_types[i] = entry_type;
-        }
-
-        let mut identity_to_json_map: [Field; MaxNumValues] = [0; MaxNumValues];
-        // 6.5 gates per iteration
-        for i in 0..MaxNumValues {
-            let id = ids[i];
-            let entry_type = entry_types[i];
+            parent_indices[i] = cast_num_to_u32(parent_index);
             // 2 gates
+            // update is 1 for end of object/array, 0 for other
             let update = TOKEN_ENDS_OBJECT_OR_ARRAY[cast_num_to_u32(entry_type)];
             // NOTE THIS RELIES ON MaxNumValues ACTUALLY DESCRIBING NUMMaxNumValues + 1
             let index = if update {
-                id
+                cast_num_to_u32(id)
             } else {
-                (MaxNumValues as Field - 1)
+                MaxNumValues - 1
             };
             // 3.5 gates
-            identity_to_json_map[cast_num_to_u32(index)] = i as Field;
+            identity_to_json_map[index] = i;
         }
-
         // 13.5 gates per iteration
         let mut parent_identity_pre = parent_indices[0];
         for i in 1..MaxNumValues {
             let parent_identity_post = parent_indices[i];
             // if the parent identity changes,
             // 3.5 gate
-            // the list is sorted according to parent_ideneity,
-            // n.b. parent_identity_post - parent_identity_pre is not neccessarily 0 or 1 (can be larger)
+            // the list is sorted according to parent_identity,
+            // n.b. parent_identity_post - parent_identity_pre is not necessarily 0 or 1 (can be larger)
             //      due to empty objects and arrays increasing identity value without creating associated child json entries
-            let new_parent = lt_field_16_bit(parent_identity_pre, parent_identity_post) as Field;
-            // let new_parent = (parent_identity_post as u32 > parent_identity_pre as u32) as Field;
+            let new_parent = parent_identity_pre < parent_identity_post;
             // 3.5 gates
-            let index_of_parent = identity_to_json_map[cast_num_to_u32(parent_identity_post)];
+            let index_of_parent = identity_to_json_map[parent_identity_post];
             // 1 gate + 3.5 gates
             let updated = JSONEntry::add_child_pointer_into_field(
-                sorted_entries[cast_num_to_u32(index_of_parent)].value,
+                sorted_entries[index_of_parent].value,
                 i as Field,
             );
 
             // RELIES ON THE SMALLEST ENTRY IN THE SORTED LIST BEING EMPTY
             // 1 gate
-            let index = (index_of_parent * new_parent);
+            let index = if new_parent { index_of_parent } else { 0 };
             // 3.5 gates
-            sorted_entries[cast_num_to_u32(index)] = JSONEntryPacked { value: updated };
+            //index is just 0 if new_parent is false, so sorted_entries[0] is useless info
+            sorted_entries[index] = JSONEntryPacked { value: updated };
 
             parent_identity_pre = parent_identity_post;
         }
-        sorted_entries[0] = JSONEntryPacked::default(); // TODO document why we want to always make 0 a dead entry
+        sorted_entries[0] = JSONEntryPacked::default();
         self.unsorted_json_entries_packed = self.json_entries_packed;
         self.json_entries_packed = sorted_entries;
         self.key_hashes = sort_result.sorted;

--- a/src/keymap.nr
+++ b/src/keymap.nr
@@ -132,11 +132,13 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         self.set_root_entry();
     }
 
-    pub(crate) unconstrained fn __find_root_entry(self) -> u32 {
+    pub(crate) unconstrained fn __find_root_entry(
+        json_entries_packed: [JSONEntryPacked; MaxNumValues],
+    ) -> u32 {
         let mut found_index = 0;
         for i in 0..MaxNumValues {
-            let entry: JSONEntry = self.json_entries_packed[i].into();
-            if (entry.parent_index == 0) & (self.json_entries_packed[i].value != 0) {
+            let entry: JSONEntry = json_entries_packed[i].into();
+            if (entry.parent_index == 0) & (json_entries_packed[i].value != 0) {
                 found_index = i;
                 break;
             }
@@ -146,7 +148,11 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
 
     pub(crate) fn set_root_entry(&mut self) {
         // Safety: check the comments below
-        let root_index = unsafe { self.__find_root_entry() };
+        let root_index = unsafe {
+            JSON::<NumBytes, NumPackedFields, MaxNumTokens, MaxNumValues, MaxKeyFields>::__find_root_entry(
+                self.json_entries_packed,
+            )
+        };
 
         let packed_entry = self.json_entries_packed[root_index];
         let entry: JSONEntry = packed_entry.into();


### PR DESCRIPTION
# Description

These unconstrained functions don't need the entire JSON struct passed in as argument, so moving them out of implementation

## Problem\*

closes https://github.com/noir-lang/noir_json_parser/issues/69

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
