### PR TITLE
feat: add get_number_from_path

### DIFF
--- a/src/get_number.nr
+++ b/src/get_number.nr
@@ -115,4 +115,26 @@ impl<let NumBytes: u32, let NumPackedFields: u32, let MaxNumTokens: u32, let Max
         let result = self.get_number_from_array(array_index);
         result.expect(f"array index out of bounds")
     }
+
+    /// if the root JSON is an object, get a nested numeric value out of the JSON, which may be several keys deep
+    pub fn get_number_from_path<let KeyBytes: u32, let PathDepth: u32>(
+        self,
+        keys: [BoundedVec<u8, KeyBytes>; PathDepth],
+    ) -> Option<u64> {
+        let mut target = self;
+        let mut valid = true;
+        for i in 0..PathDepth - 1 {
+            let child = self.get_object(keys[i]);
+
+            target = child.unwrap_unchecked();
+            valid = valid & child.is_some();
+        }
+
+        let final = target.get_number(keys[PathDepth - 1]);
+        if final.is_some() & valid {
+            final
+        } else {
+            Option::none()
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `pub fn get_number_from_path` mirroring the existing `get_string_from_path`.
- No breaking changes, no other API surface touched.

## Motivation

When the root JSON is an object, there is currently no public path to extract a numeric value at a root-level (or nested) key:

- `get_number` / `get_number_unchecked` are `pub(crate)`.
- `get_number_from_array` / `_unchecked` are `pub` but only apply when the root is an array.
- `get_value_from_path` returns a `JSONValue` with `pub(crate)` fields, so the bytes are unreachable anyway.

This PR closes that gap with the smallest possible change: one new public function, symmetric with `get_string_from_path`.

## Test plan

- [ ] Existing tests pass (`nargo test`).
- [ ] Usable externally: `let n = json.get_number_from_path([key_vec(\"exp\")]).unwrap();` resolves and returns a `u64` for a top-level numeric key.