### PR TITLE
chore: Update noir_sort dependency to version 0.4.0

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,5 +5,5 @@ authors = [""]
 compiler_version = ">=1.0.0"
 
 [dependencies]
-noir_sort = { tag = "v0.3.0", git = "https://github.com/noir-lang/noir_sort" }
+noir_sort = { tag = "v0.4.0", git = "https://github.com/noir-lang/noir_sort" }
 poseidon = { git = "https://github.com/noir-lang/poseidon", tag = "v0.3.0" }


### PR DESCRIPTION
Updates noir_sort to allow noir_json_parser to be built without the old deprecated vector syntax `&[]`

## Problem Resolved

Resolves <!-- Link to GitHub Issue -->

## Summary of Changes



## PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
